### PR TITLE
Inttag: Added PIXVALUE Keyword to DQ header

### DIFF
--- a/stistools/inttag.py
+++ b/stistools/inttag.py
@@ -248,6 +248,7 @@ def inttag(tagfile, output, starttime=None, increment=None,
             if idx == 2:
                 hdu.header['NPIX1'] = siz_axx
                 hdu.header['NPIX2'] = siz_axy
+                hdu.header['PIXVALUE'] = 0  # Fixes issue with calstis not running on raw output files
 
         # Append imset extensions to header list
         hdu_list.append(sci_hdu)


### PR DESCRIPTION
As outlined in issue #73, the raw files generated by inttag.py were not usable by calstis due to not setting the PIXVALUE keyword to 0 in the DQ header. I was able to reproduce the original issue in #73 and adding in the PIXVALUE keyword line fixed the error message that calstis presented.