### PR TITLE
Sl stis 50

### DIFF
--- a/stistools/defringe/normspflat.py
+++ b/stistools/defringe/normspflat.py
@@ -233,36 +233,48 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
             fitted = []  # This probably needs to be padded with ones to match the input shape
             if cenwave < 9800:  # 1 piece, 2 knot
                 for row in data:
-                    row_data = row[86:1109]
-                    xrange = np.arange(0, len(row_data), 1.)
-                    knots = np.linspace(0, len(row_data), 4)[1:-1]
-                    spl = LSQUnivariateSpline(xrange, row_data, knots, k=3)
+                    l_row_data = row[0:86]
+                    r_row_data = row[1109:]
+                    fit_data = row[86:1109]
+                    xrange = np.arange(0, len(fit_data), 1.)
+                    knots = np.linspace(0, len(fit_data), 4)[1:-1]
+                    spl = LSQUnivariateSpline(xrange, fit_data, knots, k=3)
                     row_fit = spl(xrange)
-                    fitted.append(row_fit)
+                    fitted_row = np.array(
+                        list(np.ones(len(l_row_data))) + list(row_fit) + list(np.ones(len(r_row_data))))
+                    fitted.append(fitted_row)
                 pass
             elif cenwave == 9851:  # 2 piece, 3 knot
                 for row in data:
-                    row_data = row[86:1109]
-                    xrange = np.arange(0, len(row_data), 1.)
-                    knots = np.linspace(0, len(row_data), 5)[1:-1]
-                    spl = LSQUnivariateSpline(xrange, row_data, knots, k=1)
+                    l_row_data = row[0:86]
+                    r_row_data = row[1109:]
+                    fit_data = row[86:1109]
+                    xrange = np.arange(0, len(fit_data), 1.)
+                    knots = np.linspace(0, len(fit_data), 5)[1:-1]
+                    spl = LSQUnivariateSpline(xrange, fit_data, knots, k=1)
                     row_fit = spl(xrange)
-                    fitted.append(row_fit)
+                    fitted_row = np.array(
+                        list(np.ones(len(l_row_data))) + list(row_fit) + list(np.ones(len(r_row_data))))
+                    fitted.append(fitted_row)
             else:  # 2 piece, 3 knot
                 for row in data:
-                    row_data = row[86:1109]
-                    xrange = np.arange(0, len(row_data), 1.)
-                    knots = np.linspace(0, len(row_data), 5)[1:-1]
-                    spl = LSQUnivariateSpline(xrange, row_data, knots, k=3)
+                    l_row_data = row[0:86]
+                    r_row_data = row[1109:]
+                    fit_data = row[86:1109]
+                    xrange = np.arange(0, len(fit_data), 1.)
+                    knots = np.linspace(0, len(fit_data), 5)[1:-1]
+                    spl = LSQUnivariateSpline(xrange, fit_data, knots, k=3)
                     row_fit = spl(xrange)
-                    fitted.append(row_fit)
+                    fitted_row = np.array(
+                        list(np.ones(len(l_row_data))) + list(row_fit) + list(np.ones(len(r_row_data))))
+                    fitted.append(fitted_row)
 
             # Write to the output file
             hdulist[1].data = np.array(fitted)
             hdulist.writeto(str(outflat.split(".")[0]) + ".fits")
             return
 
-        elif cenwave == 7751:
+        elif cenwave == 7751:  # G750L
 
             if bincols == 1:
                 startcol = 591
@@ -279,8 +291,28 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
                 endcol = 160
                 highorder = 50
                 loworder = 12
+
+            # Fit once with 2 iterations
+            # Divide this fit off the science data and store it in resp_inflat_a.fits
+            # Fit again with 2 iterations
+            # Divide this fit off the science data and store it in resp_inflat_b.fits
+
+            # make an absolute difference image of the two (a and b) flats: diff_resp_a_b.fits
+            # divide resp_b off resp_a and store this result in resp_inflat_abyb.fits (?)
+
+            # Iterate through the rows from startrow to lastrow
+            # Find the min pixel location between startcol and endcol
+            # this step is a bit difficult, it looks like they get the value of the min pixel in the abyb file and use it as a scale factor
+            # then it replaces anything left of the min pixel with the a flat and anything right of the min pixel with the b flat times the scale factor
+            # the scale factor is presumably so the two fits meet at the same point
+            # it replaces it with the b flat times the scale factor, otherwise it just uses im1
+            # this is then written out to the output file
+
+
+
             # Put spline results into tmp file and rename to output file (passes along proper header contents)
-            return
+            raise NotImplementedError
+
 
         else:
             fitted = []

--- a/stistools/defringe/normspflat.py
+++ b/stistools/defringe/normspflat.py
@@ -4,11 +4,11 @@ import os
 import numpy as np
 import warnings
 from astropy.io import fits
-from scipy.interpolate import LSQUnivariateSpline
 from astropy.nddata import utils
 
 from ..r_util import expandFileName
 from ..calstis import calstis
+from ..fit1d import fit1d
 
 
 # Keyword choices for calstis reduction:
@@ -231,39 +231,39 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
         # G750M (various CENWAVEs), G750L (i.e. CENWAVE == 7751; various binning), other (never used?)
         if opt_elem == "G750M":
             fitted = []  # This probably needs to be padded with ones to match the input shape
-            if cenwave < 9800:  # 1 piece, 2 knot
+            if cenwave < 9800:
                 for row in data:
                     l_row_data = row[0:86]
                     r_row_data = row[1109:]
                     fit_data = row[86:1109]
                     xrange = np.arange(0, len(fit_data), 1.)
-                    knots = np.linspace(0, len(fit_data), 4)[1:-1]
-                    spl = LSQUnivariateSpline(xrange, fit_data, knots, k=3)
+                    spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
+                                order=1, low_reject=5.0, high_reject=5.0, niterate=2)
                     row_fit = spl(xrange)
                     fitted_row = np.array(
                         list(np.ones(len(l_row_data))) + list(row_fit) + list(np.ones(len(r_row_data))))
                     fitted.append(fitted_row)
                 pass
-            elif cenwave == 9851:  # 2 piece, 3 knot
+            elif cenwave == 9851:
                 for row in data:
                     l_row_data = row[0:86]
                     r_row_data = row[1109:]
                     fit_data = row[86:1109]
                     xrange = np.arange(0, len(fit_data), 1.)
-                    knots = np.linspace(0, len(fit_data), 5)[1:-1]
-                    spl = LSQUnivariateSpline(xrange, fit_data, knots, k=1)
+                    spl = fit1d(xrange, fit_data, naverage=2, function="spline1",
+                                order=2, low_reject=5.0, high_reject=5.0, niterate=2)
                     row_fit = spl(xrange)
                     fitted_row = np.array(
                         list(np.ones(len(l_row_data))) + list(row_fit) + list(np.ones(len(r_row_data))))
                     fitted.append(fitted_row)
-            else:  # 2 piece, 3 knot
+            else:
                 for row in data:
                     l_row_data = row[0:86]
                     r_row_data = row[1109:]
                     fit_data = row[86:1109]
                     xrange = np.arange(0, len(fit_data), 1.)
-                    knots = np.linspace(0, len(fit_data), 5)[1:-1]
-                    spl = LSQUnivariateSpline(xrange, fit_data, knots, k=3)
+                    spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
+                                order=2, low_reject=5.0, high_reject=5.0, niterate=2)
                     row_fit = spl(xrange)
                     fitted_row = np.array(
                         list(np.ones(len(l_row_data))) + list(row_fit) + list(np.ones(len(r_row_data))))
@@ -300,14 +300,14 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
                 xrange = np.arange(0, len(fit_data), 1.)
 
                 # High Order Fit
-                knots = np.linspace(0, len(fit_data), highorder)[1:-1]
-                spl = LSQUnivariateSpline(xrange, fit_data, knots, k=1)
+                spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
+                            order=highorder, low_reject=5.0, high_reject=5.0, niterate=2)
                 fitted_row = spl(xrange)
                 fitted_highorder.append(fitted_row)
 
                 # Low Order Fit
-                knots = np.linspace(0, len(fit_data), loworder)[1:-1]
-                spl = LSQUnivariateSpline(xrange, fit_data, knots, k=1)
+                spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
+                            order=highorder, low_reject=5.0, high_reject=5.0, niterate=2)
                 fitted_row = spl(xrange)
                 fitted_loworder.append(fitted_row)
 
@@ -348,8 +348,8 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
             fitted = []
             for row in data:
                 xrange = np.arange(0, len(row), 1.)
-                knots = np.linspace(0, len(row), 22)[1:-1]  # 20 spline pieces
-                spl = LSQUnivariateSpline(xrange, row, knots, k=3)
+                spl = fit1d(xrange, row, naverage=2, function="spline3",
+                            order=20, low_reject=3.0, high_reject=3.0, niterate=2)
                 row_fit = spl(xrange)
                 fitted.append(row_fit)
 

--- a/stistools/defringe/normspflat.py
+++ b/stistools/defringe/normspflat.py
@@ -2,14 +2,22 @@
 
 import os
 import numpy as np
+import warnings
 from astropy.io import fits
 
 from ..r_util import expandFileName
 from ..calstis import calstis
 
 
-def normspflat(inflat, outflat, do_cal=True, biasfile=None, darkfile=None, pixelflat=None, 
-               wavecal=None):
+# Keyword choices for calstis reduction:
+PERFORM = {
+    'ALL':   ['DQICORR', 'BLEVCORR', 'BIASCORR', 'DARKCORR', 'FLATCORR', 'CRCORR'],
+    'G750M': ['WAVECORR', 'HELCORR', 'X2DCORR'],
+    'G750L': [],}
+OMIT_G750L = PERFORM['G750M'][:]
+
+def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
+               pixelflat=None, wavecal=None):
     """Normalize STIS CCD fringe flat.
 
     Based on PyRAF `stsdas.hst_calib.stis.normspflat task 
@@ -20,7 +28,7 @@ def normspflat(inflat, outflat, do_cal=True, biasfile=None, darkfile=None, pixel
     inflat: str
         Name of input fringe flat
     outflat: str
-        Name of normalized fringe flat output
+        Name of normalized fringe flat output or directory location.  (Default=".")
     do_cal: bool
         Perform bias and dark subtraction and CR rejection?  (Default=True)
     biasfile: str or None
@@ -41,39 +49,111 @@ def normspflat(inflat, outflat, do_cal=True, biasfile=None, darkfile=None, pixel
     """
     # These notes are based on the old STSDAS algorithm.
 
-    # strip extension from rootname of inflat (assumed to be {RAW, CRJ, SX2, X2D, clff})
+    # Determine properties of inflat (assumed to be {RAW, CRJ, SX2, X2D, clff}):
+    inflat = os.path.abspath(inflat)
+    if not os.access(inflat, os.R_OK|os.W_OK):
+        raise FileNotFoundError('Cannot access inflat:  {}'.format(inflat))
+    hdr0 = fits.getheader(inflat, ext=0)
+    rootname = hdr0['ROOTNAME']  # *** Or use something derived from os.path.basename(inflat)? ***
+    opt_elem = hdr0['OPT_ELEM'].upper()
+    if opt_elem not in ['G750L', 'G750M']:
+        raise ValueError('Unsupported opt_elem="{}"!'.format(opt_elem))
 
-    # identify wavecal
+    # *** TO DO:  Confirm inflat has >= 2 SCI exts to allow CR-rejection ***
+    # *** TO DO:  Handle NRPTEXP keyword ***
 
-    # handle outflat filename formatting (e.g. a directory is given)
+    # Identify wavecal:
+    if opt_elem == 'G750M':
+        wavecal = wavecal or expandFileName(hdr0['WAVECAL'])
+        if not os.access(wavecal, os.R_OK):
+            raise FileNotFoundError('Cannot find G750M wavecal:  {}'.format(wavecal))
+    if wavecal in [None, 'N/A', 'n/a', '']:
+        wavecal = ''  # Format for non-specified wavecals going into calstis API
+    else:
+        wavecal = os.path.abspath(wavecal)
 
-    # if do_cal:
-    #    identify biasfile, darkfile, pixelflat
-    #    confirm inflat has >= 2 SCI exts to allow CR-rejection
-    #    handle NRPTEXP keyword
-    #    PERFORM:  DQICORR, BLEVCORR, BIASCORR, DARKCORR, FLATCORR, CRCORR
-    #    Update BIASFILE, DARKFILE, PFLTFILE
-    #    if G750M:
-    #        PERFORM:  WAVECORR, HELCORR, X2DCORR
-    #    elif G750L:
-    #        OMIT:  WAVECORR, HELCORR, X2DCORR
-    #    call stistools.calstis.calstis(inflat, wavecal, ...)
-    # 
-    #    perform pixel-to-pixel flat-fielding:
-    #        if G750M:
-    #            make unity file from inflat's SX2 (trivial flat)
-    #        elif G750L:
-    #            make unity file from inflat's CRJ --> tmp
-    #            copy CRJ to clff
+    # Handle outflat filename formatting:
+    outflat = os.path.abspath(outflat)
+    if os.path.isdir(outflat):
+        outflat = os.path.join(outflat, '{}_nsp.fits'.format(rootname))
+    if not os.access(os.path.dirname(outflat), os.W_OK):
+        raise IOError('Do not have permission to write to:  {}'.format(
+                      os.path.dirname(outflat)))
 
-    # elif not do_cal:
-    #    if G750M:
-    #        make unity file from inflat's RAW --> tmp
-    #    elif G750L:
-    #        make unity file from inflat's RAW --> tmp
-    #        copy inflat's RAW --> clff
+    perform = PERFORM['ALL'] + PERFORM[opt_elem]
+    if do_cal:
+        # Resolve reference files from supplied variables or header values:
+        ref_types = {
+            'BIASFILE': os.path.abspath(biasfile  or expandFileName(hdr0['BIASFILE'])),
+            'DARKFILE': os.path.abspath(darkfile  or expandFileName(hdr0['DARKFILE'])),
+            'PFLTFILE': os.path.abspath(pixelflat or expandFileName(hdr0['PFLTFILE'])),}
 
-    # Check that G750M inflats are either sx2 or x2d.
+        # Populate/repopulate the inflat header accordingly:
+        for i, (ref_type, ref) in enumerate(ref_types.items()):
+            if not os.access(ref, os.F_OK):
+                raise FileNotFoundError('Cannot access reference file:  {}'.format(ref))
+
+            # Handle reference file paths via environment variables:
+            ref_var = 'reff{:.0f}'.format(i+1)
+            os.environ[ref_var] = os.path.abspath(os.path.dirname(ref)) + os.sep
+            # Keep $oref where it's the same:
+            if os.path.normpath(os.environ[ref_var]) == os.path.normpath(os.environ['oref']):
+                ref_var = 'oref'
+                #os.environ['oref'] = os.path.abspath(os.environ['oref'])  # for when we cd
+            with fits.open(inflat, 'update') as f:
+                if ref_var == 'oref':
+                    f[0].header[ref_type] = '{}${}'.format(ref_var, os.path.basename(ref))
+                else:
+                    f[0].header[ref_type] = '${}/{}'.format(ref_var, os.path.basename(ref))
+
+        # Update calibration flags prior to calling calstis:
+        with fits.open(inflat, 'update') as f:
+            for keyword in perform:
+                if f[0].header[keyword] != 'COMPLETE':
+                    f[0].header[keyword] = 'PERFORM'
+            if opt_elem == 'G750M':
+                output_suffix = 'sx2'  # geometrically-corrected
+            elif opt_elem == 'G750L':
+                output_suffix = 'crj'  # not geometrically-corrected
+                for keyword in OMIT_G750L:
+                    if f[0].header[keyword] == 'PERFORM':
+                        f[0].header[keyword] = 'OMIT'
+
+        # Call calstis:
+        old_cwd = os.getcwd()  # outflat and ref_vars are abs paths
+        try:
+            os.chdir(os.path.dirname(inflat))  # Must be in same directory to pick up EPC file
+            trailer = os.path.join(os.path.dirname(outflat),
+                                   '{}_calstis.log'.format(rootname))
+            outroot = os.path.dirname(outflat) + os.sep
+            outname = os.path.join(os.path.dirname(outflat),
+                                   '{}_{}.fits'.format(rootname, output_suffix))
+            # Remove files from previous iterations of this script:
+            for old_file in [outname, trailer]:
+                if os.access(old_file, os.F_OK):
+                    os.remove(old_file)
+            res = calstis(os.path.basename(inflat), wavecal=wavecal, outroot=outroot,
+                          trailer=trailer)
+            if res != 0:
+                raise Exception('CalSTIS returned non-zero code:  {}\n' \
+                                'See log for more details:  {}'.format(res, trailer))
+            print ('File written:  {}'.format(outname))
+        finally:
+            os.chdir(old_cwd)
+    else:  # not do_cal
+        outname = inflat
+
+        # Check if user-supplied inflat has all the recommended calibrations performed:
+        keyword_warnings = []
+        for keyword in perform:
+            if hdr0[keyword] != 'COMPLETE':
+                keyword_warnings.append(keyword)
+        if keyword_warnings:
+            warnings.warn('These calibration steps should be COMPLETE:\n{}'.format(
+                ', '.join(keyword_warnings)))
+
+    # Read in the calibrated flat data:
+    data = fits.getdata(outname, ext=1)
 
     # Do a line-by-line cubic spline fit to the fringe flat to remove the lamp function...
 
@@ -103,7 +183,8 @@ def call_normspflat():
     parser = argparse.ArgumentParser(
         description='Normalize STIS CCD fringe flat')
     parser.add_argument('inflat', type=str, help='Name of input fringe flat')
-    parser.add_argument('outflat', type=str, help='Name of normalized fringe flat output')
+    parser.add_argument('--outflat', '-o', type=str, default='.',
+        help='Name of normalized fringe flat output or directory location (default=".")')
     parser.add_argument('--skip_cal', '-s', dest='do_cal', action='store_false', 
         help='Skip bias and dark subtraction and CR rejection?')
     parser.add_argument('--biasfile', '-b', type=str,


### PR DESCRIPTION
Normspflat is ready for review. I tested the following use cases, which probe each of the fits possible in the codes decision tree:

G750L:
7751 - o8u201070 (DHB example)

G750M:
9336 - obdi022k0
9851 - oc2s040e0

These examples all had agreement within 1% for any given pixel, but for the majority of pixels the agreement was within <<1%. Geometrically corrected G750M data has some fitting difference between the two in how the boundaries behave. The Python code goes to unity several pixels ahead of the CL code. It seemed like this behavior was preferable as the CL script fitting spiked near the boundary in a few cases.

For G750M, there is an else case that, given the other conditionals, picks out the 9806 and 10363 cenwaves. There were no fringe flats available to test for 9806 and only one for 10363 which I had trouble getting to work as calstis claimed the science wavecal was not matching with it. Since these cenwaves only have a handful of data all taken before 2000, I figured it was better to post this review request and we can decide when testing the whole defringing suite whether to have coverage for these cenwaves.