### PR TITLE
Docstrings edits

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -113,6 +113,9 @@ html_theme = 'stsci_rtd_theme'
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
 
+# Turn off smart quotes on HTML pages:
+smartquotes = False
+
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 #html_title = None

--- a/stistools/defringe/__init__.py
+++ b/stistools/defringe/__init__.py
@@ -15,31 +15,12 @@ Routines
 - `defringe`     -- Defringe by dividing the science spectrum by the fringe flat  
 
 .. note::
-    See section 3.5.5 of the `STIS Data Handbook (DHB) <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/stis/documentation/_documents/stis_dhb.pdf>`_
-    for more details on the defringing process.
+    See the stistools documentation on readthedocs for the latest information and user guides:
+    <https://stistools.readthedocs.io/en/latest/>
+    See section 3.5.5 of the STIS Data Handbook (DHB) for more details on the defringing process:
+    <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/stis/documentation/_documents/stis_dhb.pdf>
 
 .. warning::
     These routines are based on PyRAF stsdas.hst_calib.stis defringing tasks, though 
     users should expect numerical discrepancies between these two implementations.
-
-Example
--------
-
-.. code-block:: python
-
-    from stistools import defringe
-    from astropy.io import fits
-    
-    # Apply preliminary calibrations to the raw science data (if necessary):
-    # (The output CRJ may already exist in pipeline products.)
-    defringe.prepspec('o8u201060_raw.fits', 'o8u201060_crj.fits')  # G750L
-    
-    # Normalize the contemporaneous fringe flat:
-    defringe.normspflat('o8u201070_raw.fits', 'o8u201070_nsp.fits, do_cal=True)
-    
-    # Fit the normalized fringe flat to the science data in shift and amplitude:
-    defringe.mkfringeflat('o8u201060_crj.fits', 'o8u201070_nsp.fits', 'o8u201070_frr.fits')
-    
-    # Apply the fitted fringe flat to the 
-    defringe.defringe('o8u201060_crj.fits', 'o8u201070_frr.fits', 'o8u201060_drj.fits')
 """

--- a/stistools/defringe/__init__.py
+++ b/stistools/defringe/__init__.py
@@ -37,11 +37,6 @@ Example
     # Normalize the contemporaneous fringe flat:
     defringe.normspflat('o8u201070_raw.fits', 'o8u201070_nsp.fits, do_cal=True)
     
-    # Remove fringes due to order-sorter filter, as these are already included in the
-    # sensitivity function:
-    with fits.open('o8u201070_nsp.fits', 'update') as f:
-        f[1].data[:,:250] = 1.
-    
     # Fit the normalized fringe flat to the science data in shift and amplitude:
     defringe.mkfringeflat('o8u201060_crj.fits', 'o8u201070_nsp.fits', 'o8u201070_frr.fits')
     

--- a/stistools/defringe/__init__.py
+++ b/stistools/defringe/__init__.py
@@ -9,10 +9,10 @@ HST/STIS CCD Defringing Tools
 Routines
 --------
 
-- `prepspec`     -- Correct STIS CCD G750L or G750M spectrum for fringing  
+- `prepspec`     -- Calibrate STIS CCD G750L or G750M spectrum before defringing  
 - `normspflat`   -- Normalize STIS CCD fringe flat  
 - `mkfringeflat` -- Match fringes in STIS fringe flat to those in science data  
-- `defringe`     -- Correct STIS CCD G750L or G750M spectrum for fringing  
+- `defringe`     -- Defringe by dividing the science spectrum by the fringe flat  
 
 .. note::
     See section 3.5.5 of the `STIS Data Handbook (DHB) <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/stis/documentation/_documents/stis_dhb.pdf>`_

--- a/stistools/defringe/__init__.py
+++ b/stistools/defringe/__init__.py
@@ -14,13 +14,15 @@ Routines
 - `mkfringeflat` -- Match fringes in STIS fringe flat to those in science data  
 - `defringe`     -- Defringe by dividing the science spectrum by the fringe flat  
 
+.. See the stistools documentation on readthedocs for the latest information and user guides:
+   https://stistools.readthedocs.io/
+
 .. note::
-    See the stistools documentation on readthedocs for the latest information and user guides:
-    <https://stistools.readthedocs.io/en/latest/>
-    See section 3.5.5 of the STIS Data Handbook (DHB) for more details on the defringing process:
-    <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/stis/documentation/_documents/stis_dhb.pdf>
+    See Section 3.5.5 of the `STIS Data Handbook (DHB)
+    <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/stis/documentation/_documents/stis_dhb.pdf>`_
+    for more details on the defringing process.
 
 .. warning::
-    These routines are based on PyRAF stsdas.hst_calib.stis defringing tasks, though 
+    These routines are based on PyRAF `stsdas.hst_calib.stis` defringing tasks, though 
     users should expect numerical discrepancies between these two implementations.
 """

--- a/stistools/defringe/_findloc.py
+++ b/stistools/defringe/_findloc.py
@@ -7,22 +7,22 @@ def find_loc(input, low_frac=0.2, high_frac=0.8, low_line_frac=0.4):
 
     Parameters
     ----------
-    input : ndarray
+    input: ndarray
         The input science data array for the current image set.
 
-    low_frac : float
+    low_frac: float
         Fraction of image width for the start of a slice.
 
-    high_frac : float
+    high_frac: float
         Fraction of image width for the end of a slice.
 
-    low_line_frac : float
+    low_line_frac: float
         Fraction of image height for the start of a slice for limiting the
         region over which to search for the maximum of the slit profile.
 
     Returns
     -------
-    target_locn : float or None
+    target_locn: float or None
         The location (zero based pixel coordinate) of the target in the
         cross-dispersion direction.
         None will be returned if the quadratic fit to the cross-dispersion

--- a/stistools/defringe/_fit1d.py
+++ b/stistools/defringe/_fit1d.py
@@ -20,46 +20,46 @@ def fit1d(x, y, weights=None,
     Parameters
     ----------
 
-    x : 1-d ndarray
+    x: 1-d ndarray
         The array of independent values
 
-    y : 1-d ndarray
+    y: 1-d ndarray
         The array of dependent values.  Must have same length as x, or function returns None
 
-    weights : 1-d ndarray or None
+    weights: 1-d ndarray or None
         The array of weights.  If set to None, the points are given equal weight of 1.0.  If not
         set to None, must have the same length as x and y, or the function returns None
 
-    naverage : int
+    naverage: int
         The number of adjacent elements of x, y, and weight that are averaged before
         fitting is done.  If naverage=1, no averaging is done.
 
-    function : str
+    function: str
         Fitting function.  Currently only "spline1" and "spline3" are supported
 
-    order : int
+    order: int
         Order of fitting fuction.  The number of knots in the spline fit is (order-1)
 
-    low_reject : float
+    low_reject: float
         Points with y values less than fit - low_reject*(rms deviation of data from fit) are rejected
         when the fit is iterated.  Ignored if niterate = 0.
 
-    high_reject : float
+    high_reject: float
         Points with y values greater than fit + low_reject*(rms deviation of data from fit) are rejected
         when the fit is iterated.  Ignored if niterate = 0.
 
-    niterate : int
+    niterate: int
         Number of times sigma-clipping iterations are performed.  niterate=0 corresponds to no
         sigma clipping
 
-    grow : float
+    grow: float
         Used to calculate how many elements adjacent to reject pixels are also rejected.
         Not currently implemented, but included to duplicate the IRAF fitting parameter.
 
     Returns
     -------
 
-    fit : scipy.interpolate.fitpack2.LSQUnivariateSpline object
+    fit: scipy.interpolate.fitpack2.LSQUnivariateSpline object
         The result of the fit.  It can be used to calculate the fitted
         values for the input x values:
 
@@ -92,16 +92,16 @@ def get_knots(x, number_of_knots):
     Parameters
     ----------
 
-    x : 1-d ndarray
+    x: 1-d ndarray
         The input array for which knots are to be calculated
 
-    number_of_knots : int
+    number_of_knots: int
         The number of knots to calculate
 
     Returns
     -------
 
-    knots : 1-d ndarray
+    knots: 1-d ndarray
         The array of equally-spaced knots
 
     """
@@ -122,19 +122,19 @@ def fit_once(x, y, weights, function, order):
     Parameters
     ----------
 
-    x : 1-d ndarray
+    x: 1-d ndarray
         Input array of x-values
 
-    y : 1-d array
+    y: 1-d array
         Input array of y-values
 
-    weights : 1-d array
+    weights: 1-d array
         Input array of weights
 
-    function : str
+    function: str
         Function to be fitted.  Currently only "spline1" and "spline3" are supported
 
-    order : int
+    order: int
         Order of function to be fitted.  Since only splines are currently supported,
         the order is the same as the number of equal reqions the data domain is split into,
         and 1 more than the number of equally-spaced knots.
@@ -142,7 +142,7 @@ def fit_once(x, y, weights, function, order):
     Returns
     -------
 
-    fit : scipy.interpolate.fitpack2.LSQUnivariateSpline object
+    fit: scipy.interpolate.fitpack2.LSQUnivariateSpline object
         This can be used to calculate the fitted values for the input x values:
 
         fitted_values = fit(x)
@@ -173,42 +173,42 @@ def fit_with_rejection(x, y, weights, function, order, low_reject, high_reject, 
     Parameters
     ----------
 
-    x : 1-d ndarray
+    x: 1-d ndarray
         The array of independent values
 
-    y : 1-d ndarray
+    y: 1-d ndarray
         The array of dependent values.  Must have same length as x, or function returns None
 
-    weights : 1-d ndarray or None
+    weights: 1-d ndarray or None
         The array of weights.  If set to None, the points are given equal weight of 1.0.  If not
         set to None, must have the same length as x and y, or the function returns None
 
-    function : str
+    function: str
         Fitting function.  Currently only "spline1" and "spline3" are supported
 
-    order : int
+    order: int
         Order of fitting fuction.  The number of knots in the spline fit is (order-1)
 
-    low_reject : float
+    low_reject: float
         Points with y values less than fit - low_reject*(rms deviation of data from fit) are rejected
         when the fit is iterated.  Ignored if niterate = 0.
 
-    high_reject : float
+    high_reject: float
         Points with y values greater than fit + low_reject*(rms deviation of data from fit) are rejected
         when the fit is iterated.  Ignored if niterate = 0.
 
-    niterate : int
+    niterate: int
         Number of times sigma-clipping iterations are performed.  niterate=0 corresponds to no
         sigma clipping
 
-    grow : float
+    grow: float
         Used to calculate how many elements adjacent to reject pixels are also rejected.
         Not currently implemented, but included to duplicate the IRAF fitting parameter.
 
     Returns
     -------
 
-    fit : scipy.interpolate.fitpack2.LSQUnivariateSpline object
+    fit: scipy.interpolate.fitpack2.LSQUnivariateSpline object
         The result of the fit.  It can be used to calculate the fitted
         values for the input x values:
 
@@ -241,22 +241,22 @@ def calc_rms_deviation(x, y, weights, fitted):
     Parameters
     ----------
 
-    x : 1-d ndarray
+    x: 1-d ndarray
         Input array of x-values
 
-    y : 1-d array
+    y: 1-d array
         Input array of y-values
 
-    weights : 1-d array
+    weights: 1-d array
         Input array of weights
 
-    fitted : scipy.interpolate.fitpack2.LSQUnivariateSpline object
+    fitted: scipy.interpolate.fitpack2.LSQUnivariateSpline object
         The result from running the fitting routine
 
     Returns
     -------
 
-    rms_deviation : float
+    rms_deviation: float
         The rms deviation
 
     """
@@ -276,26 +276,26 @@ def wtrebin(x, y, weights=None, nbin=1):
     Parameters
     ----------
 
-    x : 1-d ndarray
+    x: 1-d ndarray
         The array of independent values
 
-    y : 1-d ndarray
+    y: 1-d ndarray
         The array of dependent values.  Must have same length as x, or function
         returns (None, None, None)
 
-    weights : 1-d ndarray or None
+    weights: 1-d ndarray or None
         The array of weights.  If set to None, the points are given equal weight of 1.0.  If not
         set to None, must have the same length as x and y, or the function
         returns (None, None, None)
 
-    nbin : int
+    nbin: int
         The number of adjacent elements of x, y, and weight that are averaged before
         fitting is done.  If nbin=1, no averaging is done and the input arrays are returned
 
     Returns
     -------
 
-    (xout, yout, wout) : 3-tuple of ndarray objects
+    (xout, yout, wout): 3-tuple of ndarray objects
         The binned/averaged x, y, and weight arrays
 
     """

--- a/stistools/defringe/defringe.py
+++ b/stistools/defringe/defringe.py
@@ -17,18 +17,20 @@ sdqflags = 4 + 8 + 512                  # "serious" data quality flags
 
 def defringe(science_file, fringe_flat, overwrite=True, verbose=True):
     # dark_file=None, pixel_flat=None
-    """Defringe by dividing the science spectrum by the fringe flat
+    """Defringe by dividing the science spectrum by the fringe flat.
+
+    Based on the PyRAF `stsdas.hst_calib.stis.defringe` task.
 
     Parameters
     ----------
-    science_file : str
+    science_file: str
         The name of the input science file.
 
-    fringe_flat : str
+    fringe_flat: str
         The name of the input fringe flat file.  This is the output from
         `mkfringeflat`.
 
-    overwrite : bool
+    overwrite: bool
         The name of the output file will be constructed from the name of the
         input science file (`science_file`) by replacing the suffix with
         'drj' or 's2d'.  If the input name are the same a RuntimeError will
@@ -37,12 +39,12 @@ def defringe(science_file, fringe_flat, overwrite=True, verbose=True):
         the existing file will be overwritten if `overwrite` is True (the
         default is True).
 
-    verbose : bool
+    verbose: bool
         If True (the default), print more info.
 
     Returns
     -------
-    drj_filename : str
+    drj_filename: str
         The name of the output file.  This will have suffix '_drj' if the
         input is G750L data, and the output name will have suffix '_s2d'
         if the input is G750M.

--- a/stistools/defringe/mkfringeflat.py
+++ b/stistools/defringe/mkfringeflat.py
@@ -16,7 +16,7 @@ def mkfringeflat(inspec, inflat, outflat, do_shift=True, beg_shift=-0.5, end_shi
                  extrloc=None, extrsize=None, opti_spreg=None, rms_region=None):
 
     """Replacement for the IRAF cl script stsdas/pkg/hst_calib/stis/mkfringeflat.cl.  Takes
-    an input science spectrum and a fringe flat that has been normalised using the task
+    an input science spectrum and a fringe flat that has been normalized using the task
     normspflat.  The fringe flat is shifted and scaled to produce the minimum RMS when divided
     into the science data
 
@@ -44,7 +44,7 @@ def mkfringeflat(inspec, inflat, outflat, do_shift=True, beg_shift=-0.5, end_shi
         Final shift to apply to fringe flat
 
     shift_step : float
-        Step between shifts to be applied to fringe flat
+        Step-size between shifts to be applied to fringe flat
 
     do_scale : bool
         Controls whether the scaling between fringe flat and science
@@ -57,7 +57,7 @@ def mkfringeflat(inspec, inflat, outflat, do_shift=True, beg_shift=-0.5, end_shi
         Final scaling to appply to fringe flat
 
     scale_step : float
-        Step between scaling values to be applied to fringe flat
+        Step-size between scaling values to be applied to fringe flat
 
     extrloc : float or None
         Extraction location.  If set to None, this will be calculated by

--- a/stistools/defringe/mkfringeflat.py
+++ b/stistools/defringe/mkfringeflat.py
@@ -15,66 +15,66 @@ def mkfringeflat(inspec, inflat, outflat, do_shift=True, beg_shift=-0.5, end_shi
                  shift_step=0.1, do_scale=True, beg_scale=0.8, end_scale=1.2, scale_step=0.04,
                  extrloc=None, extrsize=None, opti_spreg=None, rms_region=None):
 
-    """Replacement for the IRAF cl script stsdas/pkg/hst_calib/stis/mkfringeflat.cl.  Takes
-    an input science spectrum and a fringe flat that has been normalized using the task
-    normspflat.  The fringe flat is shifted and scaled to produce the minimum RMS when divided
-    into the science data
+    """Takes an input science spectrum and a fringe flat that has been normalized using
+    the task `normspflat`.  The fringe flat is shifted and scaled to produce the minimum
+    RMS when divided into the science data.
 
+    Based on the PyRAF `stsdas.hst_calib.stis.mkfringeflat` task.
 
     Parameters
     ----------
 
-    inspec : str
+    inspec: str
         Name of input science spectrum datafile
 
-    inflat : str
+    inflat: str
         Name of input fringe flat file (usually the output from normspflat)
 
-    outflat : str
+    outflat: str
         Name of output fringe flat to be used in the defringe task
 
-    do_shift : bool
+    do_shift: bool
         Controls whether the shift between fringe flat and science data is
         to be calculated
 
-    beg_shift : float
+    beg_shift: float
         Initial shift to apply to fringe flat
 
-    end_shift : float
+    end_shift: float
         Final shift to apply to fringe flat
 
-    shift_step : float
+    shift_step: float
         Step-size between shifts to be applied to fringe flat
 
-    do_scale : bool
+    do_scale: bool
         Controls whether the scaling between fringe flat and science
         data is to be calculated
 
-    beg_scale : float
+    beg_scale: float
         Initial scaling to apply to fringe flat
 
-    end_scale : float
+    end_scale: float
         Final scaling to appply to fringe flat
 
-    scale_step : float
+    scale_step: float
         Step-size between scaling values to be applied to fringe flat
 
-    extrloc : float or None
+    extrloc: float or None
         Extraction location.  If set to None, this will be calculated by
         parabolic interpolation of the peak of the cross-dispersion
         spectral sum
 
-    extrsize : float or None
+    extrsize: float or None
         Extraction size in pixels.  If set to None, this will be set to a
         reasonable value by this routine
 
-    opti_sreg : str or None
+    opti_sreg: str or None
         A string representing the section to be used in normalizing the spectrum
         of the science target before it is divided by the shifted/scaled fringe flat.
         If set to None, a reasonable range is chosen by this routine.  Should be
         specified like a Python slice, zero indezed.
 
-    rms_region : str or None
+    rms_region: str or None
         A string representing the section to be used in the rms calculation.  If set
         to None, a reasonable range is chosen by this routine.  Should be specified
         like a Python slice, zero indexed.

--- a/stistools/defringe/normspflat.py
+++ b/stistools/defringe/normspflat.py
@@ -22,8 +22,7 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
                pixelflat=None, wavecal=None):
     """Normalize STIS CCD fringe flat.
 
-    Based on PyRAF `stsdas.hst_calib.stis.normspflat task
-    <https://github.com/spacetelescope/stsdas/blob/master/stsdas/pkg/hst_calib/stis/normspflat.cl>`_.
+    Based on the PyRAF `stsdas.hst_calib.stis.normspflat` task.
 
     Parameters
     ----------

--- a/stistools/defringe/prepspec.py
+++ b/stistools/defringe/prepspec.py
@@ -13,7 +13,7 @@ from ..calstis import calstis
 
 
 def prepspec(inspec, outroot='./', darkfile=None, pixelflat=None, initguess=None):
-    """Correct STIS CCD G750L or G750M spectrum for fringing.
+    """Calibrate STIS CCD G750L or G750M spectrum before defringing.
 
     Based on PyRAF `stsdas.hst_calib.stis.prepspec task 
     <https://github.com/spacetelescope/stsdas/blob/master/stsdas/pkg/hst_calib/stis/prepspec.cl>`_.

--- a/stistools/defringe/prepspec.py
+++ b/stistools/defringe/prepspec.py
@@ -15,8 +15,7 @@ from ..calstis import calstis
 def prepspec(inspec, outroot='./', darkfile=None, pixelflat=None, initguess=None):
     """Calibrate STIS CCD G750L or G750M spectrum before defringing.
 
-    Based on PyRAF `stsdas.hst_calib.stis.prepspec task 
-    <https://github.com/spacetelescope/stsdas/blob/master/stsdas/pkg/hst_calib/stis/prepspec.cl>`_.
+    Based on the PyRAF `stsdas.hst_calib.stis.prepspec` task.
 
     Parameters
     ----------


### PR DESCRIPTION
Initial changes and cleaning up of docstrings. Perhaps we should remove the example in __init__.py  and/or point to the website hosted documentation for implementing this?