### PR TITLE
add ipython to the environment.yml dependencies list

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - d2to1
   - stsci.distutils
   - stsci.tools
+  - ipython
   - pip:
     - stsci_rtd_theme
     - sphinx_automodapi


### PR DESCRIPTION
needed for the defringe docs `ipython3` code blocks syntax highlighting