### PR TITLE
Fix Jenkins CI testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,8 @@ bc1 = new BuildConfig()
 bc1.nodetype = "linux"
 bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
-bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
+bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
+                'oref=/grp/hst/cdbs/oref/']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal', 'scikit-image']
 bc1.build_cmds = ["pip install -e .[test,all]"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,25 +1,26 @@
+// Obtain files from source control system.
 if (utils.scm_checkout()) return
 
+// Define each build configuration, copying and overriding values as necessary.
+bc1 = new BuildConfig()
+bc1.nodetype = "linux"
+bc1.name = "release"
+// Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
+bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
+bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
+bc1.conda_packages = ['python=3.6']
+bc1.build_cmds = ["pip install -e .[test,all]"]
+bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
+bc1.failedUnstableThresh = 1
+bc1.failedFailureThresh = 6
 
-data_config = new DataConfig()
-data_config.server_id = "bytesalad"
-data_config.root = 'tests_output'
-data_config.match_prefix = '(.*)_result' // .json is appended automatically
+// Run with astropy dev and Python 3.8
+bc2 = utils.copy(bc1)
+bc2.name = "dev"
+bc2.conda_packages[0] = "python=3.8"
+bc2.build_cmds = ["pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
+                  "pip install -e .[test,all]"]
 
-
-bc0 = new BuildConfig()
-bc0.nodetype = "linux"
-bc0.name = "Install"
-bc0.conda_channels = ['https://ssb.stsci.edu/astroconda']
-bc0.conda_packages = ['python=3.6',
-                     'astropy']
-bc0.test_configs = [data_config]
-bc0.build_cmds = ["conda env update --file=doc/environment.yml -q",
-                  "with_env -n stistools python setup.py install",
-                  "with_env -n stistools conda install -q -y -c http://ssb.stsci.edu/astroconda hstcal",
-                  "with_env -n stistools conda install -q -y -c http://ssb.stsci.edu/astroconda crds"]
-bc0.test_cmds = ["with_env -n stistools conda install -q -y pytest=4.2.1",
-                 "with_env -n stistools conda install -q -y pytest-remotedata",
-                 "with_env -n stistools pytest --basetemp=tests_output --junit-xml=results.xml --bigdata"]
-
-utils.run([bc0])
+// Iterate over configurations that define the (distibuted) build matrix.
+// Spawn a host of the given nodetype for each combination and run in parallel.
+utils.run([bc1, bc2])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,7 @@ bc1 = new BuildConfig()
 bc1.nodetype = "linux"
 bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
-bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
-                'oref=/grp/hst/cdbs/oref/']
+bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal', 'scikit-image']
 bc1.build_cmds = ["pip install -e .[test,all]"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc1.conda_packages = ['python=3.6', 'pytest']
+bc1.conda_packages = ['python=3.6', 'pytest', 'crds']
 bc1.build_cmds = ["pip install -e .[test,all]"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1
@@ -17,7 +17,7 @@ bc1.failedFailureThresh = 6
 // Run with astropy dev and Python 3.8
 bc2 = utils.copy(bc1)
 bc2.name = "dev"
-bc2.conda_packages[0] = ['python=3.8', 'pytest']
+bc2.conda_packages[0] = 'python=3.8'
 bc2.build_cmds = ["pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
                   "pip install -e .[test,all]"]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,9 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 bc0 = new BuildConfig()
 bc0.nodetype = "linux"
 bc0.name = "Install"
+bc0.conda_channels = ['https://ssb.stsci.edu/astroconda']
+bc0.conda_packages = ['python=3.6',
+                     'astropy']
 bc0.test_configs = [data_config]
 bc0.build_cmds = ["conda env update --file=doc/environment.yml -q",
                   "with_env -n stistools python setup.py install",
@@ -17,6 +20,6 @@ bc0.build_cmds = ["conda env update --file=doc/environment.yml -q",
                   "with_env -n stistools conda install -q -y -c http://ssb.stsci.edu/astroconda crds"]
 bc0.test_cmds = ["with_env -n stistools conda install -q -y pytest=4.2.1",
                  "with_env -n stistools conda install -q -y pytest-remotedata",
-                 "with_env -n stistools pytest --basetemp=tests_output --junitxml=results.xml --bigdata"]
+                 "with_env -n stistools pytest --basetemp=tests_output --junit-xml=results.xml --bigdata"]
 
 utils.run([bc0])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal']
+bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal', 'skimage']
 bc1.build_cmds = ["pip install -e .[test,all]"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc1.conda_packages = ['python=3.6']
+bc1.conda_packages = ['python=3.6', 'pytest']
 bc1.build_cmds = ["pip install -e .[test,all]"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1
@@ -17,7 +17,7 @@ bc1.failedFailureThresh = 6
 // Run with astropy dev and Python 3.8
 bc2 = utils.copy(bc1)
 bc2.name = "dev"
-bc2.conda_packages[0] = "python=3.8"
+bc2.conda_packages[0] = ['python=3.8', 'pytest']
 bc2.build_cmds = ["pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
                   "pip install -e .[test,all]"]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal', 'skimage']
+bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal', 'scikit-image']
 bc1.build_cmds = ["pip install -e .[test,all]"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,19 +8,12 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc1.conda_packages = ['python=3.6', 'pytest', 'crds']
+bc1.conda_packages = ['python=3.6', 'pytest', 'crds', 'hstcal']
 bc1.build_cmds = ["pip install -e .[test,all]"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1
 bc1.failedFailureThresh = 6
 
-// Run with astropy dev and Python 3.8
-bc2 = utils.copy(bc1)
-bc2.name = "dev"
-bc2.conda_packages[0] = 'python=3.8'
-bc2.build_cmds = ["pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
-                  "pip install -e .[test,all]"]
-
 // Iterate over configurations that define the (distibuted) build matrix.
 // Spawn a host of the given nodetype for each combination and run in parallel.
-utils.run([bc1, bc2])
+utils.run([bc1])

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,0 +1,33 @@
+// Obtain files from source control system.
+// [skip ci] and [ci skip] have no effect here.
+if (utils.scm_checkout(['skip_disable':true])) return
+
+// Allow modification of the job configuration, affects all relevant build configs.
+// Pass this object in the argument list to the`run()` function below to apply these settings to the job's execution.
+jobconfig = new JobConfig()
+jobconfig.post_test_summary = true
+
+// Run nightly tests, which include the slow ones.
+bc = new BuildConfig()
+bc.nodetype = "RHEL-6"
+bc.name = "release"
+bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
+               'oref=/grp/hst/cdbs/oref/']
+bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
+bc.conda_packages = ['python=3.6']
+bc.build_cmds = ["pip install -e .[test,all]"]
+bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
+bc.failedUnstableThresh = 1
+bc.failedFailureThresh = 6
+
+// Astropy dev and Python 3.8
+bc1 = utils.copy(bc)
+bc1.name = "dev"
+bc1.conda_packages[0] = "python=3.8"
+bc1.build_cmds = ["pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
+                  "pip install -e .[test,all]"]
+
+// Iterate over configurations that define the (distributed) build matrix.
+// Spawn a host (or workdir) for each combination and run in parallel.
+// Also apply the job configuration defined in `jobconfig` above.
+utils.run([bc, bc1, jobconfig])

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -1,6 +1,5 @@
 """HSTCAL regression test helpers."""
-from astropy.extern.six.moves import urllib
-
+from six.moves import urllib
 import getpass
 import os
 import sys

--- a/tests/test_defringe.py
+++ b/tests/test_defringe.py
@@ -8,7 +8,6 @@ import pytest
 class TestDefringe(BaseSTIS):
 
     input_loc = 'defringe'
-    ref_loc = 'defringe/ref'
 
 
     def test_normspflat_g750l(self):

--- a/tests/test_defringe.py
+++ b/tests/test_defringe.py
@@ -8,6 +8,7 @@ import pytest
 class TestDefringe(BaseSTIS):
 
     input_loc = 'defringe'
+    ref_loc = 'defringe/ref'
 
 
     def test_normspflat_g750l(self):

--- a/tests/test_defringe.py
+++ b/tests/test_defringe.py
@@ -18,7 +18,7 @@ class TestDefringe(BaseSTIS):
         output = flat_file+"_nsp_out.fits"
 
         for input_file in [flat_file+'_raw.fits', sci_file+'_wav.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
         
         normspflat(flat_file+"_raw.fits",output, 
                    do_cal=True,wavecal=sci_file+"_wav.fits")
@@ -35,7 +35,7 @@ class TestDefringe(BaseSTIS):
         output = sci_file+"_crj.fits"
 
         for input_file in [sci_file+'_raw.fits', sci_file+'_wav.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
 
         prepspec(sci_file+"_raw.fits")
 
@@ -51,7 +51,7 @@ class TestDefringe(BaseSTIS):
         output = flat_file+"_frr_out.fits"
 
         for input_file in [sci_file+'_crj.fits', flat_file+'_nsp.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
 
         mkfringeflat(sci_file+"_crj.fits", flat_file+"_nsp.fits", output)
 
@@ -66,7 +66,7 @@ class TestDefringe(BaseSTIS):
         flat_file = 'o49x18020'
 
         for input_file in [sci_file+'_crj.fits', flat_file+'_frr.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
 
         output = defringe(f"{sci_file}_crj.fits",f"{flat_file}_frr.fits")
 
@@ -82,7 +82,7 @@ class TestDefringe(BaseSTIS):
         output = flat_file+"_frr_out.fits"
 
         for input_file in [flat_file+'_raw.fits', sci_file+'_wav.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
         
         normspflat(flat_file+"_raw.fits", output,
                    do_cal=True, wavecal=sci_file+"_wav.fits")
@@ -99,7 +99,7 @@ class TestDefringe(BaseSTIS):
         output = sci_file+"_sx2.fits"
 
         for input_file in [sci_file+'_raw.fits', sci_file+'_wav.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
 
         prepspec(sci_file+"_raw.fits")
 
@@ -116,7 +116,7 @@ class TestDefringe(BaseSTIS):
         output = flat_file+"_frr_out.fits"
 
         for input_file in [sci_file+'_sx2.fits', flat_file+'_nsp.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
 
         mkfringeflat(sci_file+"_sx2.fits", flat_file+"_nsp.fits", output,
                      beg_shift=-1.0, end_shift=0.5, shift_step=0.1,
@@ -133,7 +133,7 @@ class TestDefringe(BaseSTIS):
         flat_file = "oe36m10j0"
 
         for input_file in [sci_file+'_sx2.fits', flat_file+'_frr.fits']:
-            self.get_data("input", input_file)
+            self.get_input_file("input", input_file)
 
         output = defringe(f"{sci_file}_sx2.fits", f"{flat_file}_frr.fits")
 


### PR DESCRIPTION
Derived from ACSTOOLS configuration.

Also fixed `defringe` tests to retrieve reference files.

We should probably squash when ready to merge, as the details of the individual steps to get the tests working are probably not of much interest going forward.