### PR TITLE
add python=3.7 to conda create command in gettingstarted.rst

### DIFF
--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -31,7 +31,7 @@ Run the following command, you can change "stisenv" to be whatever name for the 
 
 .. code-block:: sh
 
-    $ conda create -n stisenv stsci
+    $ conda create -n stisenv python=3.7 stsci
 
 Once the installation is complete, you can access your new environment by activating it:
 


### PR DESCRIPTION
original command defaulted to python=3.8 on my machine and then hung on "solving environment." Explicitly setting python version to 3.7 as in the astroconda docs solved the problem.