### PR TITLE
remove `tomli` from `docs` build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ docs = [
     "sphinx",
     "stsci_rtd_theme",
     "sphinx_automodapi",
-    'tomli; python_version <"3.11"',
 ]
 
 [project.scripts]


### PR DESCRIPTION
`tomli` is not used in `conf.py`