### PR TITLE
change instances of `np.float` to `np.float64`

### DIFF
--- a/stistools/mktrace.py
+++ b/stistools/mktrace.py
@@ -97,7 +97,7 @@ def mktrace(fname, tracecen=0.0, weights=None):
     w = np.zeros(1024)
     w[ind] = 1
 
-    X = np.arange(1024).astype(np.float)
+    X = np.arange(1024).astype(np.float64)
     sparams = linefit.linefit(X, trace1024, weights=w)
     rparams = linefit.linefit(X, interp_trace, weights=w)
     sciline = sparams[0] + sparams[1] * X
@@ -138,7 +138,7 @@ def interp(y, n):
     """
     m = float(len(y))
     x = np.arange(m)
-    i = np.arange(n,dtype=np.float)
+    i = np.arange(n,dtype=np.float64)
     xx = i * (m-1)/n
     xind = np.searchsorted(x, xx)-1
     yy = y[xind]+(xx-x[xind])*(y[xind+1]-y[xind])/(x[xind+1]-x[xind])
@@ -402,13 +402,13 @@ class Trace:
         """
 
         sizex, sizey = specimage.shape
-        smoytrace = np.zeros(sizey).astype(np.float)
+        smoytrace = np.zeros(sizey).astype(np.float64)
         boxcar_kernel = signal.boxcar(3) / 3.0
 
         for c in np.arange(sizey):
             col = specimage[:, c]
             col = col - np.median(col)
-            smcol = ni.convolve(col, boxcar_kernel).astype(np.float)
+            smcol = ni.convolve(col, boxcar_kernel).astype(np.float64)
             fit = gfit.gfit1d(smcol, quiet=1, maxiter=15)
             smoytrace[c] = fit.params[1]
 


### PR DESCRIPTION
`numpy` has deprecated `np.float` and `np.int`, leading to this error when running tests (with `numpy==1.24.2`):
```
AttributeError: module 'numpy' has no attribute 'float'.
```