### PR TITLE
[SCSB-145] require Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 dynamic = [
     "version",
 ]
-requires-python = "3.10"
+requires-python = ">=3.10"
 
 [project.readme]
 file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 dynamic = [
     "version",
 ]
+requires-python = "3.10"
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
resolves [SCSB-145](https://jira.stsci.edu/browse/SCSB-145)

propagate Astropy's deprecation of Python 3.9 to downstream packages


> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: