### PR TITLE
Raise ImportError for missing 'hstcal' binaries

### DIFF
--- a/stistools/__init__.py
+++ b/stistools/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 from .version import *
 
+from .r_util import check_hstcal_status
+check_hstcal_status()  # Is the 'hstcal' dependency installed?
+
 from . import calstis
 from . import basic2d
 from . import ocrreject

--- a/stistools/r_util.py
+++ b/stistools/r_util.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import copy
+import shutil
 
 
 NOT_APPLICABLE = 'n/a'
@@ -84,3 +85,9 @@ def interpolate(x, values, xp):
                 break
 
     return value
+
+
+def check_hstcal_status():
+    if not shutil.which('cs0.e'):
+        raise ImportError("The 'hstcal' package binaries were not found in $PATH.  "
+                          "Please check that it is installed.")


### PR DESCRIPTION
Check the $PATH for hstcal binaries (cs0.e) when importing stistools.  Raise an ImportError if this is not found.