### PR TITLE
Repair RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,15 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: "3.8"
+  version: "3.12"
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,13 +3,13 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
 
 sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: "3.12"
+  version: "3.11"
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,13 +3,12 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: "3.11"
   install:
     - method: pip
       path: .

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,6 +25,8 @@ import stsci_rtd_theme
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0,os.path.abspath('.'))
 
+autodoc_mock_imports = ['astropy', 'scipy', 'astroquery', 'pysiaf', 'stsci']
+
 # -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,7 @@ autodoc_mock_imports = ['astropy', 'scipy', 'astroquery', 'pysiaf', 'stsci']
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.imgmath','numpydoc',
                 'sphinx.ext.intersphinx', 'sphinx.ext.coverage',
-                'sphinx.ext.autosummary',
+                'sphinx.ext.autosummary', 'sphinxcontrib.jquery',
                 'sphinx.ext.doctest']
 #extensions += ['parameter_anchor']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ docs = [
     "sphinx",
     "stsci_rtd_theme",
     "sphinx_automodapi",
+    "numpydoc",
 ]
 
 [project.scripts]

--- a/stistools/ctestis.py
+++ b/stistools/ctestis.py
@@ -94,48 +94,48 @@ def ctestis(ycol, net, sky, stisimage=None, mjd=None, nread=None,
 
     Parameters
     ----------
-    ycol : arr
+    ycol: arr
         Y-column # of object
-    net : arr
+    net: arr
         Net photometric counts (background subtracted) measured from science image
         and scaled to cosmic-ray split exposure time (from which sky is measured)
-    sky : arr
+    sky: arr
         Single-pixel sky-background estimate measured from individual cosmic-ray
         split, bias- and dark-subtracted, flat-fielded images (flt.fits) with no 
         sky subtraction
-    stisimage : str, optional
+    stisimage: str or None, optional
         The name of the SX2 file from which to pull the header keywords.
-    mjd : float, optional
+    mjd: float or None, optional
         Modified julian date corresponding to the start time of the 1st
         exposure, corresponds to the TEXPSTRT keyword. If stisimage file is
         defined TEXPSTRT keyword will overwrite any provided mjd value.
-    nread : int, optional
+    nread: int or None, optional
         Number of image sets combined during CR rejection, corresponds to the
         NCOMBINE keyword. If stisimage file is defined NCOMBINE keyword will
         overwrite any provided nread value.
-    ybin : int , optional
+    ybin: int or None, optional
         Axis2 data bin size in unbinned detector pixels, corresponds to the
         BINAXIS2 keyword. If stisimage file is defined BINAXIS2 keyword will
         overwrite any provided ybin value.
-    gain : float, optional
+    gain: float or None, optional
         The image gain, corresponds to the CCDGAIN keyword.  If stisimage file
         is defined the CCDGAIN keyword will overwrite any provided gain value.
         If the gain is 4.0, it will be upated to 4.08.
-    amp : str, optional
+    amp: str, optional [Default: 'D']
         The amplifier used for the observation (default 'D').  Ignored if
         stisimage is provided.
-    sx2 : bool, optional
+    sx2: bool, optional [Default: False]
         Force the procedure to remove the top/bottom 38 rows. This is
         automatically done if the file in stisname contains '_sx2'. Default
         values is False
 
     Returns
     -------
-    fluxc : arr
+    fluxc: arr
         The empirically-corrected flux (counts)
-    dmagc : arr
+    dmagc: arr
         The empirical photometric correction (delta mag)
-    dyc : arr
+    dyc: arr
         The empirical astrometric correction (delta pixels)
     """
 

--- a/stistools/evaldisp.py
+++ b/stistools/evaldisp.py
@@ -9,20 +9,20 @@ def newton(x, coeff, cenwave, niter=4):
     in this file assumes that the grating is first order.
 
     Parameters
-    -----------
-    x : float or ndarray
+    ----------
+    x: float or ndarray
         a single pixel number or an array of pixel numbers
-    coeff : array_like object
+    coeff: array_like object
         a list of eight elements containing the
         dispersion coefficients as read from a STIS _dsp.fits table
-    cenwave : int or float
+    cenwave: int or float
         central wavelength, in Angstroms
-    niter : int
+    niter: int
         number of iterations
 
     Returns
     -------
-    wavelength : float or ndarray
+    wavelength: float or ndarray
         a single wavelength or an array (numarray) of wavelengths,
         in Angstroms
     """
@@ -62,18 +62,18 @@ def evalDisp(coeff, wl):
     but this function converts to zero-indexed pixels.
 
     Parameters
-    -----------
-    coeff : array_like object
+    ----------
+    coeff: array_like object
         a list of eight elements containing the
         dispersion coefficients as read from a STIS _dsp.fits table
 
-    wl : float or ndarray
+    wl: float or ndarray
         a single wavelength or an array (numarray) of wavelengths,
         in Angstroms
 
     Returns
-    --------
-    pix_number : float or ndarray
+    -------
+    pix_number: float or ndarray
         the pixel number (or array of pixel numbers) corresponding
         to the input wavelength(s); note that these are zero indexed
     """

--- a/stistools/gettable.py
+++ b/stistools/gettable.py
@@ -26,25 +26,25 @@ def getTable(table, filter, sortcol=None,
     but more than one row matches the filter.
 
     Parameters
-    -----------
-    table : string
+    ----------
+    table: str
         name of the reference table
-    filter : dict
+    filter: dict
         each key is a column name, and the corresponding value
         is a possible table value in that column
-    sortcol : string
+    sortcol: str or None
         the name of a column on which to sort the table rows
         (if there is more than one matching row), or None to disable sorting
-    exactly_one : bool
+    exactly_one: bool [default: False]
         set this to True if there must be one and only one
         matching row
-    at_least_one : bool
+    at_least_one: bool [default: False]
         set this to True if there must be at least one
         matching row
 
     Returns
     -------
-    match_rows : rec_array
+    match_rows: rec_array
         an array of the rows of the table that match the filter;
         note that if only one row matches the filter, the function value
         will still be an array
@@ -130,12 +130,12 @@ def rotateTrace(trace_info, expstart):
     """Rotate a2displ, if MJD and DEGPERYR are in the trace table.
 
     Parameters
-    -----------
-    trace_info : rec_array
+    ----------
+    trace_info: rec_array
         an array of the relevant rows of the table;
         the A2DISPL column will be modified in-place if the MJD and
         DEGPERYR columns are present
-    expstart : float
+    expstart: float
         exposure start time (MJD)
     """
 

--- a/stistools/r_util.py
+++ b/stistools/r_util.py
@@ -14,13 +14,13 @@ def expandFileName(filename):
     path name for the file.
 
     Parameters
-    -----------
-    filename : str
+    ----------
+    filename: str
         A file name, possibly including an environment variable.
 
     Returns
-    --------
-    fullname : str
+    -------
+    fullname: str
         The file name with environment variable expanded.
     """
 
@@ -48,17 +48,17 @@ def interpolate(x, values, xp):
     value in values will be returned.
 
     Parameters
-    -----------
-    x : a sequence object, e.g. an array, int or float
+    ----------
+    x: a sequence object, e.g. an array, int or float
         Array of independent variable values.
-    values :  a sequence object, e.g. an array (not character)
+    values:  a sequence object, e.g. an array (not character)
         Array of dependent variable values.
-    xp : int or float
+    xp: int or float
         Independent variable value at which to interpolate.
 
     Returns
     -------
-    interp_vals : the same type as one element of values
+    interp_vals: the same type as one element of values
         Linearly interpolated value.
 
     """

--- a/stistools/radialvel.py
+++ b/stistools/radialvel.py
@@ -18,17 +18,17 @@ def radialVel(ra_targ, dec_targ, mjd):
     in the direction toward the target.
 
     Parameters
-    -----------
-    ra_targ : float
+    ----------
+    ra_targ: float
         right ascension of the target (degrees)
-    dec_targ : float
+    dec_targ: float
         declination of the target (degrees)
-    mjd : float
+    mjd: float
         Modified Julian Date at the time of observation
 
     Returns
-    --------
-    radial_vel : float
+    -------
+    radial_vel: float
         the radial velocity in km/s
     """
 
@@ -96,12 +96,12 @@ def earthVel(mjd):
 
     Parameters
     ----------
-    mjd : float
+    mjd: float
         time, Modified Julian Date
 
     Returns
     -------
-    vel :  ndarray
+    vel: ndarray
         the velocity vector of the Earth around the Sun, in
         celestial coordinates (shape=(3,),ndtype=float64)
     """
@@ -173,15 +173,15 @@ def precess(mjd, target):
     .. [2] J.H. Lieske, 1979, Astron & Astrophys vol 73, 282-284.
 
     Parameters
-    -----------
-    mjd : float
+    ----------
+    mjd: float
         time, Modified Julian Date
-    target : array_like object
+    target: array_like object
         unit vector pointing toward the target, J2000 coordinates
 
     Returns
     -------
-    vector : ndarray
+    vector: ndarray
         the target vector (or matrix) precessed to mjd as an
         array object of type float64 and the same shape as target,
         i.e. either (3,) or (n,3)

--- a/stistools/sshift.py
+++ b/stistools/sshift.py
@@ -14,7 +14,6 @@ __version__ = '1.7 (2010-Apr-27)'
 
 
 def shiftimage(infile, outfile, shift=0):
-
     """
     Shift each image extension of an input file by N rows and write the
     new image extension to the output file.
@@ -44,38 +43,37 @@ def shiftimage(infile, outfile, shift=0):
 
 def sshift(input, output=None, shifts=None, platescale=None,
            tolerance=None):
+    """Align spectra from different images of an imset.
 
-    """ Align spectra from different images of an imset.
+    Parameters
+    ----------
+    input: list
+        A list of input filenames.  These must be STIS flat-
+        fielded (_flt) image FITS files.  This argument will accept a
+        single filename or a list of filenames.
+    shifts: list of int or None, optional
+        A list of integers indicating the number of rows to shift
+        each image of each file in the cross-dispersion (Y-) direction.
+    platescale: float or None, optional
+        The size of a pixel in arcseconds.  Used to convert
+        the value of the POSTARG2 keyword to pixels.
+    tolerance: float or None, optional
+        The allowed difference between calculated shifts and
+        integer pixel shifts (fraction of pixel).
 
-Parameters
-----------
-input : list
-    A list of input filenames.  These must be STIS flat-
-    fielded (_flt) image FITS files.  This argument will accept a
-    single filename or a list of filenames.
-shifts : list, optional
-    A list of integers indicating the number of rows to shift
-    each image of each file in the cross-dispersion (Y-) direction.
-platescale : float, optional
-    The size of a pixel in arcseconds.  Used to convert
-    the value of the POSTARG2 keyword to pixels.
-tolerance : float, optional
-    The allowed difference between calculated shifts and
-    integer pixel shifts (fraction of pixel).
+    Returns
+    -------
+    output: list, optional
+        A list of output filenames. The number of output
+        filenames must match the number of input filenames.  If no output
+        is given, then the _flt substring of the input file is replace by
+        the _sfl substring to create an output file.  This option will
+        accept a single filename or a list of filenames.
 
-Returns
--------
-output : list, optional
-    A list of output filenames. The number of output
-    filenames must match the number of input filenames.  If no output
-    is given, then the _flt substring of the input file is replace by
-    the _sfl substring to create an output file.  This option will
-    accept a single filename or a list of filenames.
-
-Notes
-------
-Author:
-  - Paul Barrett (STScI)
+    Notes
+    -----
+    Author:
+      - Paul Barrett (STScI)
 
     """
 

--- a/stistools/stisnoise.py
+++ b/stistools/stisnoise.py
@@ -107,7 +107,7 @@ def windowfilter(time_series, image_type, sst, freqpeak, width, taper):
 def stisnoise(infile, exten=1, outfile=None, dc=1, verbose=1,
               boxcar=0, wipe=None, window=None):
 
-    """ Computes an FFT on STIS CCD frames to evaluate fixed pattern noise.
+    """Computes an FFT on STIS CCD frames to evaluate fixed pattern noise.
 
     Fixed pattern noise is most obvious in a FFT of bias
     frames.  Optional filtering to correct the fixed pattern noise is
@@ -115,19 +115,19 @@ def stisnoise(infile, exten=1, outfile=None, dc=1, verbose=1,
     can be saved as an output file.
 
     Parameters
-    -----------
-    infile : string
+    ----------
+    infile: str
         STIS FITS file
-    exten : int, optional
+    exten: int, optional [Default: 1]
         fits extension to be read
-    dc : int, optional
+    dc: int, optional [Default: 1]
         the power in the first freq bin is set to zero for better
         plotting of the power spectrum.
-    verbose : int, optional [Default: 1]
+    verbose: int, optional [Default: 1]
         set to 0 if you do not want brief information about each image.
-    boxcar : int
+    boxcar: int [default: 0]
         width of boxcar smoothing to be applied.
-    wipe : ndarray
+    wipe: ndarray or None
         a 3-element array, specifying how to modify the data in
         frequency space. If set, the image is converted to a 1-D time
         series, fourier transformed to frequency space, modified, inverse
@@ -135,7 +135,7 @@ def stisnoise(infile, exten=1, outfile=None, dc=1, verbose=1,
         The first and second elements specify the range in frequencies to
         be scaled (in hz), and the third element specifies the scaling
         factor (should be 0-1).
-    window : ndarray
+    window: ndarray or None
         a 3 element array, specifying how to modify the data in
         frequency space.  The first element is the center of the window
         (in hz). The second element is the width of the window (in hz).
@@ -143,19 +143,19 @@ def stisnoise(infile, exten=1, outfile=None, dc=1, verbose=1,
         scale (in hz) of the tapering width.  Specifically, a square
         bandstop is convolved with a gaussian having the FWHM given by the
         third parameter.
-    outfile : string,optional
+    outfile: str or None, optional
         name of filtered image file
 
     Returns
     -------
-    noise_terms : tuple of arrays
+    noise_terms: tuple of arrays
         A tuple containing the arrays; namely, the arrays::
 
             freq  = frequency in power spectrum (hz)
             magn  = magnitude in power spectrum
 
     Notes
-    ---------
+    -----
     Authors:
       - Original algorithm: Thomas M. Brown (STScI)
       - Python version: Paul Barrett (STScI)

--- a/stistools/wavelen.py
+++ b/stistools/wavelen.py
@@ -15,18 +15,18 @@ def compute_wavelengths(shape, phdr, hdr, helcorr):
 
     Parameters
     ----------
-    shape : tuple of two ints
+    shape: tuple of two ints
         the number of rows and columns in the output image
-    phdr :  fits Header object
+    phdr:  FITS Header object
         primary header
-    hdr : fits Header object
+    hdr: FITS Header object
         extension header
-    helcorr : string
+    helcorr: str
         "PERFORM" if heliocentric correction should be done
 
     Returns
     -------
-    wavelengths : ndarray of float64
+    wavelengths: ndarray of float64
         an array of wavelengths, of the same shape (nrows, ncols) as
         the output image
 
@@ -140,17 +140,17 @@ def get_delta_offset1(apdestab, aperture, ref_aper):
 
     Parameters
     ----------
-    apdestab : string
+    apdestab: str
         name of the aperture description table
-    aperture : string
+    aperture: str
         aperture (slit) name
-    ref_aper : string
+    ref_aper: str
         name of the reference aperture, the one that was
         used to calculate the dispersion relation
 
     Returns
     -------
-    angle : float
+    angle: float
         incidence angle offset in degrees
 
     """
@@ -179,21 +179,21 @@ def adjust_disp(ncoeff, coeff, delta_offset1, shifta1, inang_info,
 
     Parameters
     ----------
-    ncoeff : int
+    ncoeff: int
         number of dispersion coefficients
-    coeff : ndarray of float64
+    coeff: ndarray of float64
         array of dispersion coefficients, modified in-place
-    delta_offset1 : float
+    delta_offset1: float
         incidence angle offset in degrees
-    shifta1 : float
+    shifta1: float
         MSM offset (ref. pixels) in the dispersion direction
-    delta_tan : float
+    delta_tan: float
         difference in tangents of slit angle and ref angle
-    delta_row : float
+    delta_row: float
         difference between current row number and CRPIX2
-    binaxis1 : float
+    binaxis1: float
         binning factor in dispersion direction
-    inang_info : rec_array
+    inang_info: rec_array
         rows from the incidence-angle table
 
     """

--- a/stistools/wx2d.py
+++ b/stistools/wx2d.py
@@ -24,32 +24,32 @@ def wx2d(input, output, wavelengths=None, helcorr="",
 
     Parameters
     ----------
-    input : string
+    input: str
         name of input file containing an image set
-    output : string
+    output: str
         name of the output file
-    wavelengths : string, optional [Default: None]
+    wavelengths: str, optional [Default: None]
         name of the output file for wavelengths
-    helcorr : string
+    helcorr: str
         specify "perform" or "omit" to override header keyword
-    algorithm : {'wavelet', 'kd'}
+    algorithm: {'wavelet', 'kd'}
         algorithm to use in resampling the input
-    trace : string or array, or None
+    trace: str or array or None
         trace array, or name of FITS table containing trace(s)
-    order : int [Default: 7]
+    order: int [Default: 7]
         polynomial order (an odd number, e.g. 5 or 7)
-    subdiv : int [Default: 8]
+    subdiv: int [Default: 8]
         number of subpixels (a power of 2, e.g. 8 or 16)
-    psf_width : float [Default: 0.]
+    psf_width: float [Default: 0.]
         width of PSF for convolution (e.g. 1.3);
         0 means no convolution
-    rows : tuple, optional [Default: None]
+    rows: tuple, optional [Default: None]
         a tuple giving the slice of rows to process; output values
         in all other rows will be set to zero.
         The default of None means all rows, same as (0, 1024)
-    subsampled : string, optional [Default: None]
+    subsampled: str, optional [Default: None]
         name of the output file with the subsampled image
-    convolved : string, optional [Default: None]
+    convolved: str, optional [Default: None]
         name of the output file with the convolved image
 
     """
@@ -123,32 +123,32 @@ def wx2d_imset(ft, imset, output, wavelengths, helcorr,
 
     Parameters
     ----------
-    ft : HDUList
-        Fits HDUList object for the input file.
+    ft: HDUList
+        FITS HDUList object for the input file.
 
-    imset  :  int
+    imset: int
         one-indexed image set number
-    output  :  string
+    output: str
         name of the output file
-    wavelengths :  string or None
+    wavelengths: str or None
         name of the output file for wavelengths
-    helcorr :  {'perform', 'omit'}
+    helcorr: str, {'perform', 'omit'}
         specify "perform" or "omit" to override header keyword
-    algorithm : {"wavelet","kd"}
+    algorithm: str, {'wavelet', 'kd'}
         algorithm to use to process input
-    tracefile :  string or array
+    tracefile: str or array
         trace array, or name of FITS table containing trace(s)
-    order :  int
+    order: int
         polynomial order
-    subdiv :  int
+    subdiv: int
         number of subpixels
-    psf_width :  float
+    psf_width: float
         width of PSF for convolution
-    rows :  tuple
+    rows: tuple
         a tuple giving the slice of rows to process
-    subsampled :  string, or None
+    subsampled: str or None
         name of the output file with the subsampled image
-    convolved :  string, or None
+    convolved: str or None
         name of the output file with the convolved image
 
     """
@@ -251,45 +251,45 @@ def wavelet_resampling(hdu, img, errimg,
 
     Parameters
     ----------
-    hdu : fits header/data unit object
+    hdu: FITS header/data unit object
         header/data unit for a SCI extension
-    img : ndarray
+    img: ndarray
         SCI image array (could be a subset of full image)
-    errimg : ndarray
+    errimg: ndarray
         ERR image array (could be a subset of full image)
-    original_nrows : int
+    original_nrows: int
         number of image lines (NAXIS2) in input image
-    nrows : int
+    nrows: int
         number of image lines in subset
-    ncols : int
+    ncols: int
         number of image columns (NAXIS1)
-    rows : tuple
+    rows: tuple
         tuple giving the slice of rows to process
-    a2center : ndarray
+    a2center: ndarray
         1-D array of Y locations
-    a2displ : ndarray
+    a2displ: ndarray
         array of traces, one for each a2center; the length of each
         trace must be the same as the number of columns in the input image
-    offset : float
+    offset: float
         offset of the first row in 'image' from the beginning of
         the data block in the original file, needed for trace
-    shifta2 : float
+    shifta2: float
         offset of the row from nominal (from shifta2 keyword)
-    imset : int
+    imset: int
         number of the current image set (keyword EXTVER)
-    order : int
+    order: int
         polynomial order
-    subdiv : int
+    subdiv: int
         number of subpixels per input pixel
-    psf_width : float
+    psf_width: float
         width of PSF for convolution (e.g. 1.3);
-    subsampled : string or None
+    subsampled: str or None
         name of the output file with the subsampled image
-    convolved : string or None
+    convolved: str or None
         name of the output file with the convolved image
 
     Returns
-    --------
+    -------
     img_arr: tuple of ndarrays
         the image and error arrays (to replace the input img and errimg)
 
@@ -387,32 +387,32 @@ def kd_resampling(img, errimg,
 
     Parameters
     ----------
-    img :  ndarray
+    img: ndarray
         SCI image array (could be a subset of full image)
-    errimg :  ndarray
+    errimg: ndarray
         ERR image array (could be a subset of full image)
-    original_nrows :  int
+    original_nrows: int
         number of image lines (NAXIS2) in input image
-    nrows :  int
+    nrows: int
         number of image lines in subset
-    ncols :  int
+    ncols: int
         number of image columns (NAXIS1)
-    rows :  tuple
+    rows: tuple
         tuple giving the slice of rows to process
-    a2center : ndarray
+    a2center: ndarray
         1-D array of Y locations
-    a2displ :  ndarray
+    a2displ: ndarray
         array of traces, one for each a2center; the length of each
         trace must be the same as the number of columns in the input image
-    offset : float
+    offset: float
         offset of the first row in 'image' from the beginning of
         the data block in the original file, needed for trace
-    shifta2 : float
+    shifta2: float
         offset of the row from nominal (from shifta2 keyword)
 
     Returns
     -------
-    img_arr : tuple
+    img_arr: tuple
         the image and error arrays (to replace the input img and errimg)
 
     """
@@ -443,22 +443,22 @@ def kd_apply_trace(image, a2center, a2displ, offset=0., shifta2=0.):
 
     Parameters
     ----------
-    image :  ndarray
+    image: ndarray
         input 2-D image array
-    a2center : ndarray
+    a2center: ndarray
         array of Y locations
-    a2displ : ndarray
+    a2displ: ndarray
         array of traces, one for each a2center; the length of
         each trace must be the same as the number of columns in 'image'
-    offset : float
+    offset: float
         offset of the first row in 'image' from the beginning
         of the data block in the original file, needed for trace
-    shifta2 : float
+    shifta2: float
         offset of the row from nominal (from shifta2 keyword)
 
     Returns
     -------
-    x2d : ndarray
+    x2d: ndarray
         2-D array containing the resampled image
 
     """
@@ -518,14 +518,14 @@ def stis_psf(x, a):
 
     Parameters
     ----------
-    x : float
+    x: float
         offset in pixels from the center of the profile
-    a : float
+    a: float
         a measure of the width of the PSF
 
     Returns
     -------
-    val : float
+    val: float
         the PSF evaluated at x
 
     """
@@ -539,30 +539,30 @@ def apply_trace(image, a2center, a2displ, subdiv,
 
     Parameters
     ----------
-    image :  ndarray
+    image: ndarray
         input 2-D image array, oversampled by 'subdiv' in axis 0
-    a2center : ndarray
+    a2center: ndarray
         1-D array of Y locations
-    a2displ : ndarray
+    a2displ: ndarray
         array of traces, one for each a2center; the length of each
         trace must be the same as the number of columns in the input image
-    subdiv :  int
+    subdiv: int
         number of rows to add together
-    offset :  float
+    offset: float
         offset of the first row in 'image' from the beginning of
         the data block in the original file, needed for trace
-    shifta2 :  float
+    shifta2: float
         offset of the row from nominal (from shifta2 keyword)
-    extname :  string
+    extname: str
         which type of extension (SCI, ERR, DQ)?
 
     Returns
-    ---------
-    x2d : ndarray
+    -------
+    x2d: ndarray
         resampled 2-D image array
 
     Notes
-    -------
+    -----
     The function value is a 2-D array containing the resampled image.
     This is binned by subdiv in Y (axis 0), after shifting by trace
     (multiplied by subdiv).
@@ -614,18 +614,18 @@ def extract(image, locn, subdiv):
 
     Parameters
     ----------
-    image : ndarray
+    image: ndarray
         input array, oversampled by 'subdiv' in axis 0
-    locn : ndarray
+    locn: ndarray
         a 1-D array giving the location at which to extract; an
         integer value corresponds to the center of the pixel.  The length
         must be the same as the number of columns in the input image.
-    subdiv : int
+    subdiv: int
         number of rows to add together
 
     Returns
-    --------
-    spec : ndarray
+    -------
+    spec: ndarray
         a 1-D array containing the extracted row
 
     """
@@ -665,21 +665,21 @@ def extract_err(image, locn, subdiv):
 
     Parameters
     ----------
-    image : ndarray
+    image: ndarray
         input array, oversampled by 'subdiv' in axis 0
-    locn : ndarray
+    locn: ndarray
         a 1-D array giving the location at which to extract; an
         integer value corresponds to the center of the pixel
-    subdiv : int
+    subdiv: int
         number of rows to add together
 
     Returns
     -------
-    spec : ndarray
+    spec: ndarray
         a 1-D array containing the extracted row
 
     Notes
-    -------
+    -----
     This takes the square root of the average of the squares, intended to be
     used for interpolating the ERR array.  Fractions of pixels at the upper
     and lower edges are excluded.
@@ -720,17 +720,17 @@ def extract_i16(image, locn, subdiv):
 
     Parameters
     ----------
-    image : ndarray
+    image: ndarray
         input array, oversampled by 'subdiv' in axis 0
-    locn : ndarray
+    locn: ndarray
         a 1-D array giving the location at which to extract; an
         integer value corresponds to the center of the pixel
-    subdiv : int
+    subdiv: int
         number of rows to add together
 
     Returns
-    --------
-    spec : ndarray
+    -------
+    spec: ndarray
         a 1-D array containing the extracted row
 
     """
@@ -768,13 +768,13 @@ def interpolate_trace(a2center, a2displ, y, length):
 
     Parameters
     ----------
-    a2center : ndarray
+    a2center: ndarray
         array of Y locations
-    a2displ : ndarray
+    a2displ: ndarray
         array of traces, one trace for each element of a2center
-    y : float
+    y: float
         Y location on the detector
-    length : int
+    length: int
         length of a trace; needed only if traces is empty
 
     """
@@ -792,18 +792,18 @@ def trace_name(trace, phdr):
     """Return the 1dt table name or array.
 
     Parameters
-    -----------
-    trace : string or array or None
+    ----------
+    trace: str or array or None
         if trace is None the header keyword SPTRCTAB will be
-        gotten from phdr; else if this is a string it should be the name
+        gotten from phdr; else if this is a str it should be the name
         of a trace file (possibly using an environment variable); otherwise,
         it should be a trace, in which case it will be returned unchanged
-    phdr : fits Header object
+    phdr: FITS Header object
         primary header, used only if trace is None
 
     Returns
-    --------
-    tracefile : string or array
+    -------
+    tracefile: str or array
         name of a trace file (with environment variable expanded),
         or an actual trace array
 
@@ -829,17 +829,17 @@ def get_trace(tracefile, phdr, hdr):
 
     Parameters
     ----------
-    tracefile : string or array
+    tracefile: str or array
         either a trace array or the name of a FITS 1dt table
-    phdr : fits Header object
+    phdr: FITS Header object
         primary header of input file
-    hdr : fits Header object
+    hdr: FITS Header object
         extension header of input image (for binning info and
         time of exposure)
 
     Returns
-    --------
-    trace_arrays : tuple of 2 arrays
+    -------
+    trace_arrays: tuple of 2 arrays
         a pair of arrays, one is the Y location at the middle column,
         and the other is an array of trace arrays
 
@@ -893,16 +893,16 @@ def bin_traces(a2displ, binaxis1, ltv):
 
     Parameters
     ----------
-    a2displ : ndarray
+    a2displ: ndarray
         an array of one or more arrays of Y displacements (traces)
-    binaxis1 : int
+    binaxis1: int
         binning factor in the dispersion axis
-    ltv : float
+    ltv: float
         offset in the dispersion axis (one indexing)
 
     Returns
     -------
-    a2displ : ndarray
+    a2displ: ndarray
         an array of traces (a2displ), but with the trace arrays binned
         and shorter by the factor binaxis1
 
@@ -972,13 +972,13 @@ def polynomial(x, y, z, n):
 
     Parameters
     ----------
-    x : ndarray
+    x: ndarray
         the integer values from 0 through n-1 inclusive (but float64)
-    y : ndarray
+    y: ndarray
         a 2-D array, axis 0 of length n
-    z : float
+    z: float
         n / 2.
-    n : int
+    n: int
         1 + order of polynomial fit
     """
 


### PR DESCRIPTION
- Update RTD configuration file to allow builds
  - Rename file to ".readthedocs.yaml"
  - Specify OS version
  - Specify a modern python version (3.12)
- Add missing requirements to "docs" build:  `numpydoc`
- Add sphinx extension to enable search functionality:  `sphinxcontrib.jquery`
- Mock on RTD: astropy, scipy, astroquery, pysiaf, stsci
- Formatting changes to docstrings to fix parameters, clarify a few expected types and defaults
  - Format is required by our sphinx themes, even though " : " would be acceptable in standard numpy doc format.

If this PR is merged, we should close #141 and #148.  Also, deactivate unneeded RTD branches.

This branch is being built to here:  https://stistools.readthedocs.io/en/sl_rtd-2025/
(And again for the PR)