### PR TITLE
sshift r-str in re call

### DIFF
--- a/stistools/sshift.py
+++ b/stistools/sshift.py
@@ -218,7 +218,7 @@ def sshift(input, output=None, shifts=None, platescale=None,
         #  Use default output file name.
         if outfile is None:
             import re
-            outfile = re.sub('flt\.', 'sfl.', infile, count=1)
+            outfile = re.sub(r'flt\.', 'sfl.', infile, count=1)
 
         if binaxis2 == 1:
             print('{:>18}: {:3}'.format(infile, npixel))


### PR DESCRIPTION
Changed regular expression pattern to an r-str to fix python deprecation warning.

```
=============================================================================== warnings summary ===============================================================================
../stistools/sshift.py:221
  /Users/lockwood/git/stis/stistools-testing/stistools/sshift.py:221: DeprecationWarning: invalid escape sequence '\.'
    outfile = re.sub('flt\.', 'sfl.', infile, count=1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 31 passed, 1 warning in 2.66s =========================================================================
```