### PR TITLE
ISEB-99:  Fix python 3.13 & 3.14 test results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ content-type = "text/markdown"
 test = [
     "pytest",
     "ci-watson>=0.8.0",
+    "six",
 ]
 docs = [
     "ipython",
@@ -52,6 +53,7 @@ ocrreject_exam = "stistools.ocrreject_exam:call_ocrreject_exam"
 requires = [
     "setuptools>=61.2",
     "setuptools_scm[toml]>=3.4",
+    "wheel",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ content-type = "text/markdown"
 test = [
     "pytest",
     "ci-watson>=0.8.0",
-    "six",
+    "requests",
 ]
 docs = [
     "ipython",

--- a/stistools/crrej_from_raw.py
+++ b/stistools/crrej_from_raw.py
@@ -196,7 +196,7 @@ def crrej_from_raw(input, wavecal='', outroot='', savetmp=False, verbose=False,
     # Convert dict to Astropy Table:
     new_crr = create_new_crr(crr_par)
 
-    with TemporaryDirectory(prefix='crrej_from_raw_') as directory:
+    with TemporaryDirectory(prefix='crrej_from_raw_', ignore_cleanup_errors=True) as directory:
         # Write new CRREJTAB to a temporary location:
         new_crr_name = 'temp_crr.fits'
         new_crr.write(os.path.join(directory, new_crr_name))

--- a/stistools/crrej_from_raw.py
+++ b/stistools/crrej_from_raw.py
@@ -13,8 +13,8 @@ from .r_util import expandFileName
 
 
 __taskname__ = "crrej_from_raw"
-__version__ = "0.1"
-__vdate__ = "12-May-2023"
+__version__ = "0.1.1"
+__vdate__ = "21-November-2025"
 __author__ = "Sean Lockwood, STScI, May 2023."
 
 VERBOSE = False
@@ -298,8 +298,8 @@ def create_new_crr(crr_par):
     Astropy Table of CRREJECTAB contents
     '''
     # Convert to an Astropy table:
-    type_map = {'CRSPLIT': 'i2', 'MEANEXP': 'f', 'SCALENSE': 'a8', 'INITGUES': 'a8',
-                'SKYSUB': 'a4', 'CRSIGMAS': 'a20', 'CRRADIUS': 'f', 'CRTHRESH': 'f',
+    type_map = {'CRSPLIT': 'i2', 'MEANEXP': 'f', 'SCALENSE': 'S8', 'INITGUES': 'S8',
+                'SKYSUB': 'S4', 'CRSIGMAS': 'S20', 'CRRADIUS': 'f', 'CRTHRESH': 'f',
                 'BADINPDQ': 'l', 'CRMASK': bool, }
 
     if {x.upper() for x in crr_par} != {y.upper() for y in type_map}:

--- a/stistools/defringe/defringe.py
+++ b/stistools/defringe/defringe.py
@@ -66,7 +66,7 @@ def defringe(science_file, fringe_flat, overwrite=True, verbose=True):
         suffix = "_drj"
 
     sci_dir, sci_filename = os.path.split(science_file)
-    sci_root = re.split('\.fits.*', sci_filename, flags=re.IGNORECASE)[0].rsplit('_',1)[0]
+    sci_root = re.split(r'\.fits.*', sci_filename, flags=re.IGNORECASE)[0].rsplit('_',1)[0]
     drj_filename = os.path.join(sci_dir, sci_root + suffix + '.fits')
     if science_file == drj_filename:
         raise RuntimeError('The input and output file names cannot be the same.')

--- a/stistools/defringe/normspflat.py
+++ b/stistools/defringe/normspflat.py
@@ -212,7 +212,8 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
                         xrange = np.arange(0, len(fit_data), 1.)
                         spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
                                     order=1, low_reject=5.0, high_reject=5.0, niterate=2)
-                        row_fit = fit_data/spl(xrange)
+                        with np.errstate(invalid='ignore', divide='ignore'):
+                            row_fit = fit_data / spl(xrange)
                         row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
                         fitted[idx, 85:1109] = row_fit.copy()
 
@@ -223,7 +224,8 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
                         xrange = np.arange(0, len(fit_data), 1.)
                         spl = fit1d(xrange, fit_data, naverage=2, function="spline1",
                                     order=2, low_reject=5.0, high_reject=5.0, niterate=2)
-                        row_fit = fit_data/spl(xrange)
+                        with np.errstate(invalid='ignore', divide='ignore'):
+                            row_fit = fit_data / spl(xrange)
                         row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
                         fitted[idx, 85:1109] = row_fit.copy()
             else:  # This applies to cenwave 9806 and 10363
@@ -233,7 +235,8 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
                         xrange = np.arange(0, len(fit_data), 1.)
                         spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
                                     order=2, low_reject=5.0, high_reject=5.0, niterate=2)
-                        row_fit = fit_data/spl(xrange)
+                        with np.errstate(invalid='ignore', divide='ignore'):
+                            row_fit = fit_data / spl(xrange)
                         row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
                         fitted[idx, 85:1109] = row_fit.copy()
                     else:

--- a/stistools/defringe/normspflat.py
+++ b/stistools/defringe/normspflat.py
@@ -205,42 +205,41 @@ def normspflat(inflat, outflat='.', do_cal=True, biasfile=None, darkfile=None,
         if opt_elem == "G750M":
             fitted = np.ones(data.shape, dtype=data.dtype)
 
-            if cenwave < 9800:
-                for idx, row in enumerate(data):
-                    if (idx >= startrow) and (idx < lastrow):
-                        fit_data = row[85:1109]
-                        xrange = np.arange(0, len(fit_data), 1.)
-                        spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
-                                    order=1, low_reject=5.0, high_reject=5.0, niterate=2)
-                        with np.errstate(invalid='ignore', divide='ignore'):
+            with np.errstate(invalid='ignore', divide='ignore'):
+                if cenwave < 9800:
+                    for idx, row in enumerate(data):
+                        if (idx >= startrow) and (idx < lastrow):
+                            fit_data = row[85:1109]
+                            xrange = np.arange(0, len(fit_data), 1.)
+                            spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
+                                        order=1, low_reject=5.0, high_reject=5.0, niterate=2)
                             row_fit = fit_data / spl(xrange)
-                        row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
-                        fitted[idx, 85:1109] = row_fit.copy()
+                            row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
+                            fitted[idx, 85:1109] = row_fit.copy()
 
-            elif cenwave == 9851:
-                for idx, row in enumerate(data):
-                    if (idx >= startrow) and (idx < lastrow):
-                        fit_data = row[85:1109]
-                        xrange = np.arange(0, len(fit_data), 1.)
-                        spl = fit1d(xrange, fit_data, naverage=2, function="spline1",
-                                    order=2, low_reject=5.0, high_reject=5.0, niterate=2)
-                        with np.errstate(invalid='ignore', divide='ignore'):
+                elif cenwave == 9851:
+                    for idx, row in enumerate(data):
+                        if (idx >= startrow) and (idx < lastrow):
+                            fit_data = row[85:1109]
+                            xrange = np.arange(0, len(fit_data), 1.)
+                            spl = fit1d(xrange, fit_data, naverage=2, function="spline1",
+                                        order=2, low_reject=5.0, high_reject=5.0, niterate=2)
                             row_fit = fit_data / spl(xrange)
-                        row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
-                        fitted[idx, 85:1109] = row_fit.copy()
-            else:  # This applies to cenwave 9806 and 10363
-                for idx, row in enumerate(data):
-                    if (idx >= startrow) and (idx < lastrow):
-                        fit_data = row[85:1109]
-                        xrange = np.arange(0, len(fit_data), 1.)
-                        spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
-                                    order=2, low_reject=5.0, high_reject=5.0, niterate=2)
-                        with np.errstate(invalid='ignore', divide='ignore'):
+                            row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
+                            fitted[idx, 85:1109] = row_fit.copy()
+
+                else:  # This applies to cenwave 9806 and 10363
+                    for idx, row in enumerate(data):
+                        if (idx >= startrow) and (idx < lastrow):
+                            fit_data = row[85:1109]
+                            xrange = np.arange(0, len(fit_data), 1.)
+                            spl = fit1d(xrange, fit_data, naverage=2, function="spline3",
+                                        order=2, low_reject=5.0, high_reject=5.0, niterate=2)
                             row_fit = fit_data / spl(xrange)
-                        row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
-                        fitted[idx, 85:1109] = row_fit.copy()
-                    else:
-                        fitted[idx, :] = 1.
+                            row_fit[np.where(row_fit == 0.0)] = 1.0  # avoid zeros in output flat
+                            fitted[idx, 85:1109] = row_fit.copy()
+                        else:
+                            fitted[idx, :] = 1.
 
             # Write to the output file
             hdulist[1].data = fitted.copy()

--- a/stistools/defringe/prepspec.py
+++ b/stistools/defringe/prepspec.py
@@ -65,7 +65,7 @@ def prepspec(inspec, outroot='./', darkfile=None, pixelflat=None, initguess=None
     #    return SX2 file
 
     science_data = os.path.abspath(expandFileName(inspec))
-    sci_root = re.split('\.fits.*', os.path.basename(science_data),
+    sci_root = re.split(r'\.fits.*', os.path.basename(science_data),
         flags=re.IGNORECASE)[0].rsplit('_', 1)[0]
     opt_elem = fits.getval(science_data, 'OPT_ELEM').strip().upper()
     if (fits.getval(science_data, ext=0, keyword='DETECTOR').strip().upper() != 'CCD') or \

--- a/stistools/gettable.py
+++ b/stistools/gettable.py
@@ -69,7 +69,7 @@ def getTable(table, filter, sortcol=None,
 
         # Test for for wildcards in the table.
         wild = None
-        if isinstance(column, np.chararray):
+        if isinstance(column, (str, bytes)):
             wild = (column == STRING_WILDCARD)
         elif isinstance(column[0], np.integer):
             wild = (column == INT_WILDCARD)

--- a/stistools/inttag.py
+++ b/stistools/inttag.py
@@ -51,8 +51,8 @@ Examples
 """
 
 __taskname__ = "inttag"
-__version__ = "1.1"
-__vdate__ = "27-March-2024"
+__version__ = "1.1.1"
+__vdate__ = "21-November-2025"
 __author__ = "Python: Doug Branton, C code: R. Katsanis, N. Zarate, Phil Hodge"
 
 

--- a/stistools/inttag.py
+++ b/stistools/inttag.py
@@ -183,13 +183,7 @@ def inttag(tagfile, output, starttime=None, increment=None,
         dq_hdu = fits.ImageHDU(header=tag_sci_hdr.copy(), name='DQ')
 
         # Generate datetime for 'DATE' header keyword
-        dtstr = str(dt.utcnow())
-        date, h, m, s = [dtstr.split()[0], dtstr.split()[1].split(':')[0], dtstr.split()[1].split(':')[1],
-                         str(round(float(dtstr.split()[1].split(':')[-1])))]
-        if len(s) == 1:
-            s = '0' + s
-
-        dtval = date + 'T' + h + ':' + m + ':' + s
+        dtval = dt.now().isoformat().rsplit('.', 1)[0]
 
         # Populate extensions
         for idx, hdu in enumerate([sci_hdu, err_hdu, dq_hdu]):

--- a/stistools/mktrace.py
+++ b/stistools/mktrace.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 import os
 import os.path
 import stat
-from scipy import signal
+from scipy.signal.windows import boxcar
 from scipy import ndimage as ni
 
 from stsci.tools import gfit, linefit
@@ -40,8 +40,8 @@ Simple example of running mktrace on a STIS file named 'file.fits':
 
 """
 
-__version__ = '2.0.0'
-__vdate__ = '2017-03-20'
+__version__ = '2.0.1'
+__vdate__ = '2025-11-19'
 
 
 def mktrace(fname, tracecen=0.0, weights=None):
@@ -407,7 +407,7 @@ class Trace:
 
         sizex, sizey = specimage.shape
         smoytrace = np.zeros(sizey).astype(np.float64)
-        boxcar_kernel = signal.boxcar(3) / 3.0
+        boxcar_kernel = boxcar(3) / 3.0
 
         for c in np.arange(sizey):
             col = specimage[:, c]

--- a/stistools/mktrace.py
+++ b/stistools/mktrace.py
@@ -99,7 +99,7 @@ def mktrace(fname, tracecen=0.0, weights=None):
     w = np.zeros(1024)
     w[ind] = 1
 
-    X = np.arange(1024).astype(np.float64)
+    X = np.arange(1024, dtype=float)
     sparams = linefit.linefit(X, trace1024, weights=w)
     rparams = linefit.linefit(X, interp_trace, weights=w)
     sciline = sparams[0] + sparams[1] * X
@@ -140,7 +140,7 @@ def interp(y, n):
     """
     m = float(len(y))
     x = np.arange(m)
-    i = np.arange(n,dtype=np.float64)
+    i = np.arange(n, dtype=float)
     xx = i * (m-1)/n
     xind = np.searchsorted(x, xx)-1
     yy = y[xind]+(xx-x[xind])*(y[xind+1]-y[xind])/(x[xind+1]-x[xind])
@@ -374,7 +374,7 @@ class Trace:
             y2 = sizex
         specimage = data[y1:y2+1, :]
         smoytrace = self.gFitTrace(specimage, y1, y2)
-        med11smoytrace = ni.median_filter(smoytrace, 11)
+        med11smoytrace = ni.median_filter(smoytrace, 11, output=float)
         med11smoytrace[0] = med11smoytrace[2]
         diffmed = abs(smoytrace - med11smoytrace)
         tolerence = 3 * np.median(abs(smoytrace[wind] - med11smoytrace[wind]))
@@ -387,7 +387,7 @@ class Trace:
         # Convolve with a gaussian to smooth it.
         fwhm = 10.
         sigma = fwhm / 2.355
-        gaussconvxsmoytrace = ni.gaussian_filter1d(smoytrace, sigma)
+        gaussconvxsmoytrace = ni.gaussian_filter1d(smoytrace, sigma, output=float)
 
         # Compute the trace center as the median of the pixels
         # with nonzero weights.
@@ -406,13 +406,13 @@ class Trace:
         """
 
         sizex, sizey = specimage.shape
-        smoytrace = np.zeros(sizey).astype(np.float64)
+        smoytrace = np.zeros(sizey, dtype=float)
         boxcar_kernel = boxcar(3) / 3.0
 
         for c in np.arange(sizey):
             col = specimage[:, c]
             col = col - np.median(col)
-            smcol = ni.convolve(col, boxcar_kernel).astype(np.float64)
+            smcol = ni.convolve(col, boxcar_kernel, output=float)
             fit = gfit.gfit1d(smcol, quiet=1, maxiter=15)
             smoytrace[c] = fit.params[1]
 

--- a/stistools/radialvel.py
+++ b/stistools/radialvel.py
@@ -188,7 +188,6 @@ def precess(mjd, target):
     """
 
     target_j2000 = N.array(target, dtype=N.float64)
-    target_mjd = target_j2000.copy()
 
     dt = (mjd - REFDATE) / 36525.
     dt2 = dt**2
@@ -222,12 +221,4 @@ def precess(mjd, target):
     a[2, 1] = -sin_theta * sin_zeta
     a[2, 2] =  cos_theta
 
-    # Convert to matrix objects.
-    m_a = N.matrix(a)
-    m_target_j2000 = N.matrix(target_j2000)
-
-    # The prefix "m_" indicates that the product is actually a matrix.
-    m_target_mjd = m_a * m_target_j2000.T
-
-    # Return a simple array (rather than a matrix).
-    return m_target_mjd.T.A[0]
+    return a @ target_j2000

--- a/stistools/stisnoise.py
+++ b/stistools/stisnoise.py
@@ -6,9 +6,10 @@ from astropy.io import fits
 import numpy
 import numpy.fft as fft
 from scipy import ndimage
-from scipy import signal
+from scipy.signal.windows import boxcar as boxcar_window
+from scipy.signal import correlate
 
-__version__ = '5.6.1 (2025-Nov-19)'
+__version__ = '5.6.1 (2025-Nov-24)'
 
 
 def _median(arg):
@@ -96,7 +97,7 @@ def windowfilter(time_series, image_type, sst, freqpeak, width, taper):
     kernx = numpy.arange(kernw)
     kerny = gauss(kernx, kernw//2, sigma, 1.0)  # gaussian kernel
     kerny = kerny/numpy.sum(kerny)
-    filterc = signal.correlate(filter, kerny, mode='same')
+    filterc = correlate(filter, kerny, mode='same')
     tran = tran * filterc
     # inverse transform
     time_series = fft.ifft(tran).real[:ntime+2]
@@ -264,7 +265,7 @@ def stisnoise(infile, exten=1, outfile=None, dc=1, verbose=1,
     # if median is not None:
     #    time_series = medianfilter(time_series, median)
     if boxcar > 0:
-        boxcar_filter = signal.windows.boxcar(boxcar) / boxcar
+        boxcar_filter = boxcar_window(boxcar) / boxcar
         time_series = ndimage.convolve(time_series, boxcar_filter)
 
     elif wipe is not None:

--- a/stistools/stisnoise.py
+++ b/stistools/stisnoise.py
@@ -8,7 +8,7 @@ import numpy.fft as fft
 from scipy import ndimage
 from scipy import signal
 
-__version__ = '5.6 (2016-Mar-02)'
+__version__ = '5.6.1 (2025-Nov-19)'
 
 
 def _median(arg):
@@ -264,7 +264,7 @@ def stisnoise(infile, exten=1, outfile=None, dc=1, verbose=1,
     # if median is not None:
     #    time_series = medianfilter(time_series, median)
     if boxcar > 0:
-        boxcar_filter = signal.boxcar(boxcar) / boxcar
+        boxcar_filter = signal.windows.boxcar(boxcar) / boxcar
         time_series = ndimage.convolve(time_series, boxcar_filter)
 
     elif wipe is not None:

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -7,7 +7,7 @@ __all__ = ['cmp_fitshdr', 'cmp_gen_hdrkeywords',
            'word_precision_check',
            'download', 'check_url']
 
-RE_URL = re.compile('\w+://\S+')
+RE_URL = re.compile(r'\w+://\S+')
 
 default_compare = dict(
     ignore_keywords=['DATE', 'CAL_VER', 'CAL_VCS', 'CRDS_VER', 'CRDS_CTX'],

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -276,18 +276,18 @@ class BaseCal(object):
                     # be used to replace the truth files (if OK).
                     updated_outputs.append((actual, desired))
 
-        if not all_okay:
-            # Write out JSON file to enable retention of different results
-            new_truths = [os.path.abspath(i[1]) for i in updated_outputs]
-            for files in updated_outputs:
-                print("Renaming {} as new 'truth' file: {}".format(
-                      files[0], files[1]))
-                shutil.move(files[0], files[1])
-            log_pattern = [os.path.join(os.path.dirname(x), '*.log')
-                           for x in new_truths]
-            upload_results(pattern=new_truths + log_pattern,
-                           testname=testname,
-                           target=tree)
+        #if not all_okay:
+        #    # Write out JSON file to enable retention of different results
+        #    new_truths = [os.path.abspath(i[1]) for i in updated_outputs]
+        #    for files in updated_outputs:
+        #        print("Renaming {} as new 'truth' file: {}".format(
+        #              files[0], files[1]))
+        #        shutil.move(files[0], files[1])
+        #    log_pattern = [os.path.join(os.path.dirname(x), '*.log')
+        #                   for x in new_truths]
+        #    upload_results(pattern=new_truths + log_pattern,
+        #                   testname=testname,
+        #                   target=tree)
 
         if not all_okay and raise_error:
             raise AssertionError(os.linesep + creature_report)

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -1,5 +1,5 @@
 """HSTCAL regression test helpers."""
-from six.moves import urllib
+import urllib.request
 import getpass
 import os
 import sys

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -276,6 +276,9 @@ class BaseCal(object):
                     # be used to replace the truth files (if OK).
                     updated_outputs.append((actual, desired))
 
+        ## Commenting out the following block as it doesn't currently function and breaks
+        ## some tests.  Retaining logic here to prompt future testing upgrades.
+
         #if not all_okay:
         #    # Write out JSON file to enable retention of different results
         #    new_truths = [os.path.abspath(i[1]) for i in updated_outputs]

--- a/tests/test_crrej_from_raw.py
+++ b/tests/test_crrej_from_raw.py
@@ -51,7 +51,7 @@ def make_mock_crr(filename):
 class Test_crrej_from_raw:
     @classmethod
     def setup_class(cls):
-        cls.refdir = TemporaryDirectory(prefix='test_crrej_from_raw_ref_')
+        cls.refdir = TemporaryDirectory(prefix='test_crrej_from_raw_ref_', ignore_cleanup_errors=True)
         os.environ[ENVIRON_VAR] = cls.refdir.name + os.path.sep
         make_mock_crr(os.path.join(cls.refdir.name, CRDS_REF_FILE))
         cls.crds_ref_file = f"${ENVIRON_VAR}/{CRDS_REF_FILE}"
@@ -63,7 +63,7 @@ class Test_crrej_from_raw:
 
     def setup_method(self, method):
         self.cwd = os.getcwd()
-        self.directory = TemporaryDirectory(prefix='test_crrej_from_raw_')
+        self.directory = TemporaryDirectory(prefix='test_crrej_from_raw_', ignore_cleanup_errors=True)
         os.chdir(self.directory.name)
         self.filename = 'test.fits'
         make_mock_datafile(self.filename, crds_ref=self.crds_ref_file)

--- a/tests/test_defringe.py
+++ b/tests/test_defringe.py
@@ -9,6 +9,10 @@ class TestDefringe(BaseSTIS):
 
     input_loc = 'defringe'
 
+    # Numerical tolerances to pass FITSDiff:
+    rtol = 5e-6
+    atol = 1e-5
+
 
     def test_normspflat_g750l(self):
         """Compare normspflat output for a g750l spectrum"""

--- a/tests/test_mktrace.py
+++ b/tests/test_mktrace.py
@@ -1,5 +1,6 @@
 from stistools.mktrace import mktrace
 from .resources import BaseSTIS
+import re
 import pytest
 
 
@@ -11,6 +12,7 @@ class TestMktrace(BaseSTIS):
     ref_loc = 'mktrace'
 
     atol = 1e-14
+    rtol = 2e-4
 
     def test_mktrace_t1(self, capsys):
         """
@@ -28,9 +30,16 @@ class TestMktrace(BaseSTIS):
 
         # Compare results
         captured = capsys.readouterr()
-        assert captured.out == "Traces were rotated by 0.0066273929 degrees \n" \
-                               "\n" \
-                               "trace is centered on row 509.2475494293\n"
+        m = re.search(
+            r"Traces were rotated by ([0-9.]+) degrees.*?"
+            r"trace is centered on row ([0-9.]+)",
+            captured.out,
+            re.S)
+        angle = float(m.group(1))
+        row = float(m.group(2))
+
+        assert angle == pytest.approx(0.0066273929, rel=1e-6)
+        assert row == pytest.approx(509.2475494293, rel=1e-6)
 
         outputs = [("o45a03010_crj_1dt.fits", "o45a03010_crj_1dt_ref.fits"),
                    ("o45a03010_crj_1dt_interp.fits", "o45a03010_crj_1dt_interp_ref.fits"),
@@ -57,9 +66,16 @@ class TestMktrace(BaseSTIS):
 
         # Compare results
         captured = capsys.readouterr()
-        assert captured.out == "Traces were rotated by 0.0317233207 degrees \n" \
-                               "\n" \
-                               "trace is centered on row 893.7059688464\n"
+        m = re.search(
+            r"Traces were rotated by ([0-9.]+) degrees.*?"
+            r"trace is centered on row ([0-9.]+)",
+            captured.out,
+            re.S)
+        angle = float(m.group(1))
+        row = float(m.group(2))
+
+        assert angle == pytest.approx(0.0317233207, rel=1e-6)
+        assert row == pytest.approx(893.7059688464, rel=1e-6)
 
         outputs = [("o8pp31020_crj_1dt.fits", "o8pp31020_crj_1dt_ref.fits"),
                    ("o8pp31020_crj_1dt_interp.fits", "o8pp31020_crj_1dt_interp_ref.fits"),

--- a/tests/test_tastis.py
+++ b/tests/test_tastis.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.mark.bigdata
 @pytest.mark.slow
-class TestDoppinfo(BaseSTIS):
+class TestTastis(BaseSTIS):
 
     input_loc = 'tastis'
     ref_loc = 'tastis'
@@ -40,14 +40,14 @@ class TestDoppinfo(BaseSTIS):
                                "                    axis1 axis2     axis1  axis2         V2   V3\n" \
                                "                      (pixels)        (arcsec)           (arcsec)\n" \
                                "Estimated slew:      0.0  -0.1     0.000 -0.005     -0.004  0.004\n" \
-                               "Flux in post-slew confirmation image (751752) - Pedestal (748587) = 3165 DN\n" \
+                               "Flux in post-slew confirmation image (751752) - Pedestal (748587) = 3165 Counts\n" \
                                "-------------------------------------------------------------------------------\n" \
                                "The flux in the confirmation image is 320% greater than the maximum flux\n" \
                                "in the ACQ/PEAK scan.  An excess greater than 100% indicates\n" \
                                "problems in the ACQ/PEAK.\n" \
                                "\n" \
                                "The flux in the confirmation image is 16% of the recommended minimum\n" \
-                               "of 20000 DN for a dispersed-light ACQ/PEAK.  The signal-to-noise in\n" \
+                               "of 20000 Counts for a dispersed-light ACQ/PEAK.  The signal-to-noise in\n" \
                                "the ACQ/PEAK may be inadequate for an accurate centering.\n" \
                                "\n" \
                                "===============================================================================\n"
@@ -86,7 +86,7 @@ class TestDoppinfo(BaseSTIS):
                                "                    axis1 axis2     axis1  axis2         V2   V3\n" \
                                "                      (pixels)        (arcsec)           (arcsec)\n" \
                                "Estimated slew:      0.2   0.0     0.010  0.000      0.007  0.007\n" \
-                               "Flux in post-slew confirmation image (852814) - Pedestal (791686) = 61128 DN\n" \
+                               "Flux in post-slew confirmation image (852814) - Pedestal (791686) = 61128 Counts\n" \
                                "-------------------------------------------------------------------------------\n" \
                                "The flux in the confirmation image is only 73% of the maximum flux\n" \
                                "in the ACQ/PEAK scan.  Percentages below 80% often indicate problems\n" \
@@ -127,14 +127,14 @@ class TestDoppinfo(BaseSTIS):
                                "                    axis1 axis2     axis1  axis2         V2   V3\n" \
                                "                      (pixels)        (arcsec)           (arcsec)\n" \
                                "Estimated slew:      0.2   0.0     0.010  0.000      0.007  0.007\n" \
-                               "Flux in post-slew confirmation image (882661) - Pedestal (871184) = 11477 DN\n" \
+                               "Flux in post-slew confirmation image (882661) - Pedestal (871184) = 11477 Counts\n" \
                                "-------------------------------------------------------------------------------\n" \
                                "The flux in the confirmation image is 110% greater than the maximum flux\n" \
                                "in the ACQ/PEAK scan.  An excess greater than 100% indicates\n" \
                                "problems in the ACQ/PEAK.\n" \
                                "\n" \
                                "The flux in the confirmation image is 57% of the recommended minimum\n" \
-                               "of 20000 DN for a dispersed-light ACQ/PEAK.  The signal-to-noise in\n" \
+                               "of 20000 Counts for a dispersed-light ACQ/PEAK.  The signal-to-noise in\n" \
                                "the ACQ/PEAK may be inadequate for an accurate centering.\n" \
                                "\n" \
                                "The maximum flux in the sequence occurred at one end.\n" \
@@ -175,7 +175,7 @@ class TestDoppinfo(BaseSTIS):
                                "                    axis1 axis2     axis1  axis2         V2   V3\n" \
                                "                      (pixels)        (arcsec)           (arcsec)\n" \
                                "Estimated slew:     -2.6   0.0    -0.132  0.000     -0.093 -0.093\n" \
-                               "Flux in post-slew confirmation image (56705) - Pedestal (43530) = 13175 DN\n" \
+                               "Flux in post-slew confirmation image (56705) - Pedestal (43530) = 13175 Counts\n" \
                                "-------------------------------------------------------------------------------\n" \
                                "The flux in the confirmation image is only 77% of the maximum flux\n" \
                                "in the ACQ/PEAK scan.  Percentages below 80% often indicate problems\n" \
@@ -219,7 +219,7 @@ class TestDoppinfo(BaseSTIS):
                                "                    axis1 axis2     axis1  axis2         V2   V3\n" \
                                "                      (pixels)        (arcsec)           (arcsec)\n" \
                                "Estimated slew:      0.0   0.0     0.000  0.000      0.000  0.000\n" \
-                               "Flux in post-slew confirmation image (907707) - Pedestal (838752) = 68955 DN\n" \
+                               "Flux in post-slew confirmation image (907707) - Pedestal (838752) = 68955 Counts\n" \
                                "-------------------------------------------------------------------------------\n" \
                                "The confirmation image has a flux between 0.8 and 2.0 times the\n" \
                                "maximum flux in the peakup, which is typical of a successful ACQ/PEAK.\n" \
@@ -251,7 +251,7 @@ class TestDoppinfo(BaseSTIS):
                                "ACQ params:     bias sub: 1510   checkbox: 3      method: FLUX CENTROID\n" \
                                "subarray (axis1,axis2):   size=(100,100)          corner=(487,466)\n" \
                                "-------------------------------------------------------------------------------\n" \
-                               "Coarse locate phase:           Target flux in max checkbox (DN): 1560\n" \
+                               "Coarse locate phase:           Target flux in max checkbox (Counts): 1560\n" \
                                "\n" \
                                "                       global          local\n" \
                                "                    axis1 axis2     axis1 axis2\n" \
@@ -261,7 +261,7 @@ class TestDoppinfo(BaseSTIS):
                                "                      (pixels)        (arcsec)            (arcsec)\n" \
                                "Estimated slew:     -1.5  -9.0    -0.079 -0.457       -0.379  0.268\n" \
                                "-------------------------------------------------------------------------------\n" \
-                               "Fine locate phase:            Target flux in max checkbox (DN): 1559\n" \
+                               "Fine locate phase:            Target flux in max checkbox (Counts): 1559\n" \
                                "\n" \
                                "                       global            local\n" \
                                "                    axis1 axis2     axis1 axis2\n" \
@@ -306,7 +306,7 @@ class TestDoppinfo(BaseSTIS):
                                "ACQ params:     bias sub: 1510   checkbox: 3      method: FLUX CENTROID\n" \
                                "subarray (axis1,axis2):   size=(100,100)          corner=(487,466)\n" \
                                "-------------------------------------------------------------------------------\n" \
-                               "Coarse locate phase:           Target flux in max checkbox (DN): 278\n" \
+                               "Coarse locate phase:           Target flux in max checkbox (Counts): 278\n" \
                                "\n" \
                                "                       global          local\n" \
                                "                    axis1 axis2     axis1 axis2\n" \
@@ -316,7 +316,7 @@ class TestDoppinfo(BaseSTIS):
                                "                      (pixels)        (arcsec)            (arcsec)\n" \
                                "Estimated slew:     21.3  -43.0     1.080 -2.184       -0.781  2.308\n" \
                                "-------------------------------------------------------------------------------\n" \
-                               "Fine locate phase:            Target flux in max checkbox (DN): 280\n" \
+                               "Fine locate phase:            Target flux in max checkbox (Counts): 280\n" \
                                "\n" \
                                "                       global            local\n" \
                                "                    axis1 axis2     axis1 axis2\n" \
@@ -360,7 +360,7 @@ class TestDoppinfo(BaseSTIS):
                                "ACQ params:     bias sub: 1510   checkbox: 3      method: FLUX CENTROID\n" \
                                "subarray (axis1,axis2):   size=(100,100)          corner=(487,466)\n" \
                                "-------------------------------------------------------------------------------\n" \
-                               "Coarse locate phase:           Target flux in max checkbox (DN): 1442\n" \
+                               "Coarse locate phase:           Target flux in max checkbox (Counts): 1442\n" \
                                "\n" \
                                "                       global          local\n" \
                                "                    axis1 axis2     axis1 axis2\n" \
@@ -370,7 +370,7 @@ class TestDoppinfo(BaseSTIS):
                                "                      (pixels)        (arcsec)            (arcsec)\n" \
                                "Estimated slew:     -7.9  -2.9    -0.400 -0.147       -0.387 -0.179\n" \
                                "-------------------------------------------------------------------------------\n" \
-                               "Fine locate phase:            Target flux in max checkbox (DN): 611\n" \
+                               "Fine locate phase:            Target flux in max checkbox (Counts): 611\n" \
                                "\n" \
                                "                       global            local\n" \
                                "                    axis1 axis2     axis1 axis2\n" \
@@ -425,7 +425,7 @@ class TestDoppinfo(BaseSTIS):
               "ACQ params:     bias sub: 1510   checkbox: 3      method: GEOMETRIC-CENTER\n" \
               "subarray (axis1,axis2):   size=(104,104)          corner=(485,464)\n" \
               "-------------------------------------------------------------------------------\n" \
-              "Coarse locate phase:           Target flux in max checkbox (DN): 87956\n" \
+              "Coarse locate phase:           Target flux in max checkbox (Counts): 87956\n" \
               "\n" \
               "                       global          local\n" \
               "                    axis1 axis2     axis1 axis2\n" \
@@ -435,7 +435,7 @@ class TestDoppinfo(BaseSTIS):
               "                      (pixels)        (arcsec)            (arcsec)\n" \
               "Estimated slew:     -7.7  -1.0    -0.393 -0.051       -0.314 -0.242\n" \
               "-------------------------------------------------------------------------------\n" \
-              "Fine locate phase:            Target flux in max checkbox (DN): 87849\n" \
+              "Fine locate phase:            Target flux in max checkbox (Counts): 87849\n" \
               "\n" \
               "                       global            local\n" \
               "                    axis1 axis2     axis1 axis2\n" \
@@ -482,7 +482,7 @@ class TestDoppinfo(BaseSTIS):
            "                    axis1 axis2     axis1  axis2         V2   V3\n" \
            "                      (pixels)        (arcsec)           (arcsec)\n" \
            "Estimated slew:     -0.2   0.0    -0.010  0.000     -0.007 -0.007\n" \
-           "Flux in post-slew confirmation image (40210) - Pedestal (35982) = 4228 DN\n" \
+           "Flux in post-slew confirmation image (40210) - Pedestal (35982) = 4228 Counts\n" \
            "-------------------------------------------------------------------------------\n" \
            "The confirmation image has a flux between 0.8 and 2.0 times the\n" \
            "maximum flux in the peakup, which is typical of a successful ACQ/PEAK.\n" \

--- a/tests/test_wx2d.py
+++ b/tests/test_wx2d.py
@@ -12,6 +12,7 @@ class TestWx2d(BaseSTIS):
     input_loc = 'wx2d'
     ref_loc = 'wx2d'
 
+    rtol = 6e-4
 
     def test_wx2d_t1(self):
         """


### PR DESCRIPTION
**Jira Ticket:**  [ISEB-99](https://jira.stsci.edu/browse/ISEB-99)

Resolves errors, failures, and warnings in `stistools` for python 3.10 - 3.14.  Not tested in python < 3.10.

On plhstins8 (RHEL 9.6):
```bash
cd /home/lockwood/stistools
conda create --name stistools-py313 python='3.13' hstcal='3.1.0' pytest
conda activate stistools-py313
pip install '.[test]'

pytest -vv --bigdata --slow --env dev tests/ > pytest_313_results.txt
```

~**ISEB Review Request:**  Please provide feedback by Wed 2025-Nov-26.~ [DONE]